### PR TITLE
Set default preset and 1x3 layout

### DIFF
--- a/modules/settings.js
+++ b/modules/settings.js
@@ -9,11 +9,11 @@ const DEFAULT_SETTINGS = {
   openMode: 'tab',  // 'tab' or 'popup'
   enterKeyBehavior: {
     enabled: true,
-    preset: 'swapped',  // 'default', 'swapped', 'slack', 'discord', 'custom'
+    preset: 'default',  // 'default', 'swapped', 'slack', 'discord', 'custom'
     newlineKey: 'Enter',
-    newlineModifiers: { shift: false, ctrl: false, alt: false, meta: false },
+    newlineModifiers: { shift: true, ctrl: false, alt: false, meta: false },
     sendKey: 'Enter',
-    sendModifiers: { shift: true, ctrl: false, alt: false, meta: false }
+    sendModifiers: { shift: false, ctrl: false, alt: false, meta: false }
   }
 };
 

--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -175,7 +175,7 @@ function registerRuntimeMessageListener() {
 async function loadSettings() {
   try {
     const settings = await chrome.storage.sync.get({
-      multiPanelLayout: '2x2',
+      multiPanelLayout: '1x3',
       multiPanelProviders: DEFAULT_PROVIDERS,
       openMode: 'tab'
     });

--- a/options/options.html
+++ b/options/options.html
@@ -88,7 +88,7 @@
             <select id="multi-panel-layout-select">
               <option value="1x1">1x1 Single Panel (1 panel)</option>
               <option value="1x2">1x2 Two Columns (2 panels)</option>
-              <option value="1x3">1x3 Three Columns (3 panels)</option>
+              <option value="1x3" selected>1x3 Three Columns (3 panels)</option>
               <option value="1x4">1x4 Four Columns (4 panels)</option>
               <option value="1x5">1x5 Five Columns (5 panels)</option>
               <option value="1x6">1x6 Six Columns (6 panels)</option>
@@ -193,8 +193,8 @@
             </div>
             <div class="setting-control">
               <select id="enter-preset-select">
-                <option value="default" data-i18n="presetDefault">Default (Enter=Send, Shift+Enter=Newline)</option>
-                <option value="swapped" selected data-i18n="presetSwapped">Swapped (Enter=Newline, Shift+Enter=Send)</option>
+                <option value="default" selected data-i18n="presetDefault">Default (Enter=Send, Shift+Enter=Newline)</option>
+                <option value="swapped" data-i18n="presetSwapped">Swapped (Enter=Newline, Shift+Enter=Send)</option>
                 <option value="slack" data-i18n="presetSlack">Slack-style (Enter=Send, Ctrl+Enter=Newline)</option>
                 <option value="discord" data-i18n="presetDiscord">Discord-style (Enter=Newline, Ctrl+Enter=Send)</option>
                 <option value="custom" data-i18n="presetCustom">Custom</option>

--- a/options/options.js
+++ b/options/options.js
@@ -197,9 +197,9 @@ async function loadSettings() {
   // Enter key behavior settings
   const enterBehavior = settings.enterKeyBehavior || {
     enabled: true,
-    preset: 'swapped',
-    newlineModifiers: { shift: false, ctrl: false, alt: false, meta: false },
-    sendModifiers: { shift: true, ctrl: false, alt: false, meta: false }
+    preset: 'default',
+    newlineModifiers: { shift: true, ctrl: false, alt: false, meta: false },
+    sendModifiers: { shift: false, ctrl: false, alt: false, meta: false }
   };
 
   const enterBehaviorToggle = document.getElementById('enter-behavior-toggle');
@@ -210,7 +210,7 @@ async function loadSettings() {
 
   const enterPresetSelect = document.getElementById('enter-preset-select');
   if (enterPresetSelect) {
-    enterPresetSelect.value = enterBehavior.preset || 'swapped';
+    enterPresetSelect.value = enterBehavior.preset || 'default';
     updateCustomEnterSettingsVisibility(enterBehavior.preset);
   }
 
@@ -510,7 +510,7 @@ function setupEventListeners() {
   const multiPanelLayoutSelect = document.getElementById('multi-panel-layout-select');
   if (multiPanelLayoutSelect) {
     // Load saved layout
-    chrome.storage.sync.get({ multiPanelLayout: '2x2' }, (result) => {
+    chrome.storage.sync.get({ multiPanelLayout: '1x3' }, (result) => {
       multiPanelLayoutSelect.value = result.multiPanelLayout;
     });
 


### PR DESCRIPTION
## Summary
- default Enter preset to Default and sync initial modifiers
- set default multi-panel layout to 1x3 in settings and panel load
- update options UI defaults to reflect new selections

## Testing
- Not run (UI change only)
