### PR TITLE
Remove auto-paste prompt library setting

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -169,7 +169,6 @@ insidebar.ai requests the following Chrome extension permissions:
 | `contextMenus` | Add "Send to insidebar.ai" option when right-clicking |
 | `declarativeNetRequest` | Allow AI provider websites to load in the sidebar (bypass X-Frame-Options) |
 | `declarativeNetRequestWithHostAccess` | Apply header modifications for specific AI provider domains |
-| `clipboardRead` | Read clipboard content when using auto-paste feature |
 | `management` | Detect installation type (Chrome Web Store vs manual) to show/hide update checking |
 | Host permissions | Access AI provider websites to load them in the sidebar |
 

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -116,12 +116,6 @@
   "btnConfigureEdge": {
     "message": "In Edge konfigurieren"
   },
-  "labelAutoPaste": {
-    "message": "Zwischenablage automatisch in Prompt-Bibliothek einfügen"
-  },
-  "descAutoPaste": {
-    "message": "Fügt den Inhalt der Zwischenablage automatisch in den Arbeitsbereich ein, wenn die Prompt-Bibliothek mit Befehl+Umschalt+L geöffnet wird"
-  },
   "sectionChatHistory": {
     "message": "Chat-Verlauf"
   },
@@ -301,12 +295,6 @@
   },
   "msgShortcutDisabled": {
     "message": "Tastaturkürzel deaktiviert"
-  },
-  "msgAutoPasteEnabled": {
-    "message": "Automatisches Einfügen aktiviert"
-  },
-  "msgAutoPasteDisabled": {
-    "message": "Automatisches Einfügen deaktiviert"
   },
   "msgEnterCustomizationEnabled": {
     "message": "Enter-Tasten-Anpassung aktiviert"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -167,12 +167,6 @@
   "btnConfigureEdge": {
     "message": "Configure in Edge"
   },
-  "labelAutoPaste": {
-    "message": "Auto-paste Clipboard to Prompt Library"
-  },
-  "descAutoPaste": {
-    "message": "Automatically paste clipboard content to workspace when opening Prompt Library with Command+Shift+L"
-  },
   "sectionChatHistory": {
     "message": "Chat History"
   },
@@ -352,12 +346,6 @@
   },
   "msgShortcutDisabled": {
     "message": "Keyboard shortcut disabled"
-  },
-  "msgAutoPasteEnabled": {
-    "message": "Auto-paste enabled"
-  },
-  "msgAutoPasteDisabled": {
-    "message": "Auto-paste disabled"
   },
   "msgSourceUrlPlacementUpdated": {
     "message": "Source URL placement updated"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -116,12 +116,6 @@
   "btnConfigureEdge": {
     "message": "Configurar en Edge"
   },
-  "labelAutoPaste": {
-    "message": "Pegar Automáticamente Portapapeles en Biblioteca de Prompts"
-  },
-  "descAutoPaste": {
-    "message": "Pega automáticamente el contenido del portapapeles en el espacio de trabajo al abrir la Biblioteca de Prompts con Command+Shift+L"
-  },
   "sectionChatHistory": {
     "message": "Historial de Chat"
   },
@@ -301,12 +295,6 @@
   },
   "msgShortcutDisabled": {
     "message": "Atajo de teclado deshabilitado"
-  },
-  "msgAutoPasteEnabled": {
-    "message": "Pegado automático habilitado"
-  },
-  "msgAutoPasteDisabled": {
-    "message": "Pegado automático deshabilitado"
   },
   "msgEnterCustomizationEnabled": {
     "message": "Personalización de tecla Enter habilitada"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -116,12 +116,6 @@
   "btnConfigureEdge": {
     "message": "Configurer dans Edge"
   },
-  "labelAutoPaste": {
-    "message": "Coller automatiquement le presse-papiers dans la bibliothèque de prompts"
-  },
-  "descAutoPaste": {
-    "message": "Coller automatiquement le contenu du presse-papiers dans l'espace de travail lors de l'ouverture de la bibliothèque de prompts avec Command+Maj+L"
-  },
   "sectionChatHistory": {
     "message": "Historique des conversations"
   },
@@ -301,12 +295,6 @@
   },
   "msgShortcutDisabled": {
     "message": "Raccourci clavier désactivé"
-  },
-  "msgAutoPasteEnabled": {
-    "message": "Collage automatique activé"
-  },
-  "msgAutoPasteDisabled": {
-    "message": "Collage automatique désactivé"
   },
   "msgEnterCustomizationEnabled": {
     "message": "Personnalisation de la touche Entrée activée"

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -116,12 +116,6 @@
   "btnConfigureEdge": {
     "message": "Configura in Edge"
   },
-  "labelAutoPaste": {
-    "message": "Incolla automaticamente appunti nella Libreria Prompt"
-  },
-  "descAutoPaste": {
-    "message": "Incolla automaticamente il contenuto degli appunti nell'area di lavoro quando si apre la Libreria Prompt con Command+Shift+L"
-  },
   "sectionChatHistory": {
     "message": "Cronologia chat"
   },
@@ -301,12 +295,6 @@
   },
   "msgShortcutDisabled": {
     "message": "Scorciatoia da tastiera disattivata"
-  },
-  "msgAutoPasteEnabled": {
-    "message": "Incolla automatico attivato"
-  },
-  "msgAutoPasteDisabled": {
-    "message": "Incolla automatico disattivato"
   },
   "msgEnterCustomizationEnabled": {
     "message": "Personalizzazione tasto Invio attivata"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -116,12 +116,6 @@
   "btnConfigureEdge": {
     "message": "Edge で設定"
   },
-  "labelAutoPaste": {
-    "message": "プロンプトライブラリにクリップボードを自動貼り付け"
-  },
-  "descAutoPaste": {
-    "message": "Command + Shift + L でプロンプトライブラリを開くときに、ワークスペースにクリップボードの内容を自動的に貼り付けます"
-  },
   "sectionChatHistory": {
     "message": "チャット履歴"
   },
@@ -301,12 +295,6 @@
   },
   "msgShortcutDisabled": {
     "message": "キーボードショートカットが無効になりました"
-  },
-  "msgAutoPasteEnabled": {
-    "message": "自動貼り付けが有効になりました"
-  },
-  "msgAutoPasteDisabled": {
-    "message": "自動貼り付けが無効になりました"
   },
   "msgEnterCustomizationEnabled": {
     "message": "Enter キーのカスタマイズが有効になりました"

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -116,12 +116,6 @@
   "btnConfigureEdge": {
     "message": "Edge 에서 구성"
   },
-  "labelAutoPaste": {
-    "message": "프롬프트 라이브러리에 클립보드 자동 붙여넣기"
-  },
-  "descAutoPaste": {
-    "message": "Command + Shift + L 로 프롬프트 라이브러리를 열 때 작업 영역에 클립보드 내용을 자동으로 붙여넣습니다"
-  },
   "sectionChatHistory": {
     "message": "채팅 기록"
   },
@@ -301,12 +295,6 @@
   },
   "msgShortcutDisabled": {
     "message": "키보드 단축키가 비활성화되었습니다"
-  },
-  "msgAutoPasteEnabled": {
-    "message": "자동 붙여넣기가 활성화되었습니다"
-  },
-  "msgAutoPasteDisabled": {
-    "message": "자동 붙여넣기가 비활성화되었습니다"
   },
   "msgEnterCustomizationEnabled": {
     "message": "Enter 키 사용자 지정이 활성화되었습니다"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -116,12 +116,6 @@
   "btnConfigureEdge": {
     "message": "Настроить в Edge"
   },
-  "labelAutoPaste": {
-    "message": "Автовставка из буфера в библиотеку промптов"
-  },
-  "descAutoPaste": {
-    "message": "Автоматически вставлять содержимое буфера обмена в рабочее пространство при открытии библиотеки промптов с помощью Command+Shift+L"
-  },
   "sectionChatHistory": {
     "message": "История чатов"
   },
@@ -301,12 +295,6 @@
   },
   "msgShortcutDisabled": {
     "message": "Горячие клавиши отключены"
-  },
-  "msgAutoPasteEnabled": {
-    "message": "Автовставка включена"
-  },
-  "msgAutoPasteDisabled": {
-    "message": "Автовставка отключена"
   },
   "msgEnterCustomizationEnabled": {
     "message": "Настройка клавиши Enter включена"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -116,12 +116,6 @@
   "btnConfigureEdge": {
     "message": "在 Edge 中配置"
   },
-  "labelAutoPaste": {
-    "message": "自动粘贴剪贴板到提示词库"
-  },
-  "descAutoPaste": {
-    "message": "使用 Command + Shift + L 打开提示词库时自动将剪贴板内容粘贴到工作区"
-  },
   "sectionChatHistory": {
     "message": "聊天历史"
   },
@@ -301,12 +295,6 @@
   },
   "msgShortcutDisabled": {
     "message": "键盘快捷键已禁用"
-  },
-  "msgAutoPasteEnabled": {
-    "message": "自动粘贴已启用"
-  },
-  "msgAutoPasteDisabled": {
-    "message": "自动粘贴已禁用"
   },
   "msgEnterCustomizationEnabled": {
     "message": "回车键自定义已启用"

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -116,12 +116,6 @@
   "btnConfigureEdge": {
     "message": "在 Edge 中設定"
   },
-  "labelAutoPaste": {
-    "message": "自動貼上剪貼簿到提示詞庫"
-  },
-  "descAutoPaste": {
-    "message": "使用 Command + Shift + L 開啟提示詞庫時自動將剪貼簿內容貼上到工作區"
-  },
   "sectionChatHistory": {
     "message": "聊天記錄"
   },
@@ -301,12 +295,6 @@
   },
   "msgShortcutDisabled": {
     "message": "鍵盤快速鍵已停用"
-  },
-  "msgAutoPasteEnabled": {
-    "message": "自動貼上已啟用"
-  },
-  "msgAutoPasteDisabled": {
-    "message": "自動貼上已停用"
   },
   "msgEnterCustomizationEnabled": {
     "message": "Enter 鍵自訂已啟用"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,6 @@
     "contextMenus",
     "declarativeNetRequest",
     "declarativeNetRequestWithHostAccess",
-    "clipboardRead",
     "downloads"
   ],
 

--- a/options/options.html
+++ b/options/options.html
@@ -252,21 +252,6 @@
           Import curated meta-prompts for AI workflows, research, coding, and analysis
         </p>
 
-        <div class="setting-item">
-          <div class="setting-info">
-            <div class="setting-label" data-i18n="labelAutoPaste">Auto-paste Clipboard to Prompt Library</div>
-            <div class="setting-description" data-i18n="descAutoPaste">
-              Automatically paste clipboard content to workspace when opening Prompt Library with Command+Shift+L
-            </div>
-          </div>
-          <div class="setting-control">
-            <label class="switch">
-              <input type="checkbox" id="auto-paste-toggle" />
-              <span class="slider"></span>
-            </label>
-          </div>
-        </div>
-
         <div class="library-import-card">
           <div class="library-header">
             <h3 data-i18n="labelDefaultPromptLibrary">Default Prompt Library</h3>

--- a/options/options.js
+++ b/options/options.js
@@ -176,12 +176,6 @@ async function loadSettings() {
   }
   updateShortcutHelperVisibility(keyboardShortcutEnabled);
 
-  // Auto-paste clipboard setting
-  const autoPasteToggle = document.getElementById('auto-paste-toggle');
-  if (autoPasteToggle) {
-    autoPasteToggle.checked = settings.autoPasteClipboard === true;
-  }
-
   // Source URL placement setting
   const sourceUrlPlacementSelect = document.getElementById('source-url-placement-select');
   if (sourceUrlPlacementSelect) {
@@ -401,16 +395,6 @@ function setupEventListeners() {
       await saveSetting('keyboardShortcutEnabled', enabled);
       updateShortcutHelperVisibility(enabled);
       showStatus('success', enabled ? t('msgShortcutEnabled') : t('msgShortcutDisabled'));
-    });
-  }
-
-  // Auto-paste clipboard toggle
-  const autoPasteToggle = document.getElementById('auto-paste-toggle');
-  if (autoPasteToggle) {
-    autoPasteToggle.addEventListener('change', async (e) => {
-      const enabled = e.target.checked;
-      await saveSetting('autoPasteClipboard', enabled);
-      showStatus('success', enabled ? t('msgAutoPasteEnabled') : t('msgAutoPasteDisabled'));
     });
   }
 


### PR DESCRIPTION
## Summary\n- remove auto-paste clipboard setting UI and handlers\n- drop related locale strings and permission note\n- remove clipboardRead permission from manifest\n\n## Testing\n- Playwright: verified #auto-paste-toggle is absent on options page