### PR TITLE
fix: reset prompt filters when closing modal

### DIFF
--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -1407,6 +1407,9 @@ function openPromptModal() {
 function closePromptModal() {
   document.getElementById('prompt-modal').style.display = 'none';
   document.getElementById('prompt-search').value = '';
+  // Reset filters to show all prompts on next open
+  currentPromptFilter = 'all';
+  currentCategoryFilter = '';
 }
 
 // ===== Provider Switcher =====


### PR DESCRIPTION
## Summary
Fix the issue where Prompt Library only shows the last applied prompt when reopened.

## Problem
After applying a prompt from the library, reopening the Prompt Library would only display that single prompt instead of all available prompts.

## Root Cause
The `closePromptModal()` function didn't reset the filter states (`currentPromptFilter` and `currentCategoryFilter`). Since the default filter is `'recent'`, only prompts with a `lastUsed` timestamp were shown - which was just the one that was applied.

## Solution
Reset filters in `closePromptModal()`:
- `currentPromptFilter = 'all'` - Show all prompts
- `currentCategoryFilter = ''` - Clear category filter

## Testing
- Tested with agent browser
- Verified all prompts display after applying one and reopening