### PR TITLE
fix: reduce permission scope for Chrome Web Store review

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3,7 +3,7 @@
     "message": "Panelize"
   },
   "extensionDescription": {
-    "message": "Compare AI chatbots side-by-side. Use ChatGPT, Claude, Gemini, Grok & more in one window."
+    "message": "Compare AI assistants side by side in one window. Send one prompt and review responses faster."
   },
   "commandOpenSidebar": {
     "message": "Open Panelize"

--- a/content-scripts/page-content-extractor.js
+++ b/content-scripts/page-content-extractor.js
@@ -2,11 +2,16 @@
 // Extracts clean page content using Mozilla Readability.js
 // Used when context menu is invoked without text selection
 //
-// This content script runs on all pages and listens for extraction requests
+// This content script is injected on demand and listens for extraction requests
 // from the service worker (context menu handler)
 
 (function() {
   'use strict';
+
+  if (window.__panelizePageExtractorLoaded) {
+    return;
+  }
+  window.__panelizePageExtractorLoaded = true;
 
   /**
    * Extract page content using Readability.js

--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,14 @@
   "manifest_version": 3,
   "name": "Panelize",
   "version": "1.0.0",
-  "description": "Compare AI chatbots side-by-side. Use ChatGPT, Claude, Gemini, Grok & more in one window.",
+  "description": "Compare AI assistants side by side in one window. Send one prompt and review responses faster.",
   "default_locale": "en",
 
   "permissions": [
     "storage",
     "contextMenus",
+    "activeTab",
+    "scripting",
     "declarativeNetRequest",
     "declarativeNetRequestWithHostAccess"
   ],
@@ -156,15 +158,6 @@
       
       "run_at": "document_end",
       "all_frames": true
-    },
-    {
-      "matches": ["<all_urls>"],
-      "js": [
-        "libs/Readability.js",
-        "content-scripts/page-content-extractor.js"
-      ],
-      "run_at": "document_idle",
-      "all_frames": false
     }
   ],
 


### PR DESCRIPTION
## Summary
- update extension summary/description metadata to remove keyword-heavy phrasing
- remove automatic all_urls content script injection for page extraction
- add activeTab and scripting permissions for on-demand injection only
- inject Readability/page extractor from service worker only after explicit user action
- add duplicate-injection guard to page extractor script

## Why
- reduce review risk and align with least-privilege expectations for Chrome Web Store
- keep context-menu extraction working while avoiding persistent all-sites injection

## Validation
- npx vitest run tests/*.test.js (pass)
