### PR TITLE
fix: restore default Enter key behavior mapping

### DIFF
--- a/content-scripts/enter-behavior-utils.js
+++ b/content-scripts/enter-behavior-utils.js
@@ -2,6 +2,12 @@
 // Supports customizable key combinations for newline and send actions
 
 let enterKeyConfig = null;
+const DEFAULT_ENTER_KEY_BEHAVIOR = {
+  enabled: true,
+  preset: 'default',
+  newlineModifiers: { shift: true, ctrl: false, alt: false, meta: false },
+  sendModifiers: { shift: false, ctrl: false, alt: false, meta: false }
+};
 
 function enableEnterSwap() {
   window.addEventListener("keydown", handleEnterSwap, { capture: true });
@@ -9,6 +15,51 @@ function enableEnterSwap() {
 
 function disableEnterSwap() {
   window.removeEventListener("keydown", handleEnterSwap, { capture: true });
+}
+
+function normalizeEnterKeyBehavior(config) {
+  const source = config && typeof config === 'object' ? config : {};
+  const newlineModifiers = source.newlineModifiers && typeof source.newlineModifiers === 'object'
+    ? source.newlineModifiers
+    : DEFAULT_ENTER_KEY_BEHAVIOR.newlineModifiers;
+  const sendModifiers = source.sendModifiers && typeof source.sendModifiers === 'object'
+    ? source.sendModifiers
+    : DEFAULT_ENTER_KEY_BEHAVIOR.sendModifiers;
+
+  return {
+    enabled: source.enabled !== false,
+    preset: typeof source.preset === 'string' ? source.preset : DEFAULT_ENTER_KEY_BEHAVIOR.preset,
+    newlineModifiers: {
+      shift: newlineModifiers.shift === undefined ? DEFAULT_ENTER_KEY_BEHAVIOR.newlineModifiers.shift : newlineModifiers.shift === true,
+      ctrl: newlineModifiers.ctrl === undefined ? DEFAULT_ENTER_KEY_BEHAVIOR.newlineModifiers.ctrl : newlineModifiers.ctrl === true,
+      alt: newlineModifiers.alt === undefined ? DEFAULT_ENTER_KEY_BEHAVIOR.newlineModifiers.alt : newlineModifiers.alt === true,
+      meta: newlineModifiers.meta === undefined ? DEFAULT_ENTER_KEY_BEHAVIOR.newlineModifiers.meta : newlineModifiers.meta === true
+    },
+    sendModifiers: {
+      shift: sendModifiers.shift === undefined ? DEFAULT_ENTER_KEY_BEHAVIOR.sendModifiers.shift : sendModifiers.shift === true,
+      ctrl: sendModifiers.ctrl === undefined ? DEFAULT_ENTER_KEY_BEHAVIOR.sendModifiers.ctrl : sendModifiers.ctrl === true,
+      alt: sendModifiers.alt === undefined ? DEFAULT_ENTER_KEY_BEHAVIOR.sendModifiers.alt : sendModifiers.alt === true,
+      meta: sendModifiers.meta === undefined ? DEFAULT_ENTER_KEY_BEHAVIOR.sendModifiers.meta : sendModifiers.meta === true
+    }
+  };
+}
+
+function setEnterKeyConfig(config) {
+  enterKeyConfig = normalizeEnterKeyBehavior(config);
+
+  if (enterKeyConfig.enabled) {
+    enableEnterSwap();
+  } else {
+    disableEnterSwap();
+  }
+}
+
+function loadEnterBehaviorFromLocal() {
+  chrome.storage.local.get({
+    enterKeyBehavior: DEFAULT_ENTER_KEY_BEHAVIOR
+  }, (data) => {
+    setEnterKeyConfig(data.enterKeyBehavior);
+  });
 }
 
 // Check if event matches the configured modifiers
@@ -33,26 +84,20 @@ function getTargetModifiers(actionType) {
 
 function applyEnterSwapSetting() {
   chrome.storage.sync.get({
-    enterKeyBehavior: {
-      enabled: true,
-      preset: 'swapped',
-      newlineModifiers: { shift: false, ctrl: false, alt: false, meta: false },
-      sendModifiers: { shift: true, ctrl: false, alt: false, meta: false }
-    }
+    enterKeyBehavior: DEFAULT_ENTER_KEY_BEHAVIOR
   }, (data) => {
-    enterKeyConfig = data.enterKeyBehavior;
-
-    if (enterKeyConfig.enabled) {
-      enableEnterSwap();
-    } else {
-      disableEnterSwap();
+    if (chrome.runtime.lastError) {
+      loadEnterBehaviorFromLocal();
+      return;
     }
+
+    setEnterKeyConfig(data.enterKeyBehavior);
   });
 }
 
 // Listen for settings changes
 chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === "sync" && changes.enterKeyBehavior) {
+  if ((area === "sync" || area === "local") && changes.enterKeyBehavior) {
     applyEnterSwapSetting();
   }
 });


### PR DESCRIPTION
## Summary
- fix fallback default enter key mapping in content scripts
- use default preset (Enter=Send, Shift+Enter=Newline) instead of swapped fallback
- normalize partial/malformed enter key settings to prevent inverted behavior
- add local-storage fallback loading when sync storage is unavailable
- react to both sync and local enterKeyBehavior changes

## Why
Some users saw inverted behavior (Shift+Enter to send) even when preset UI showed Default, caused by fallback mismatch in content script settings loading.

## Validation
- npx vitest run tests/*.test.js (pass, 136 tests)
