### PR TITLE
fix: default focus unified input on Panelize page load

### DIFF
--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -84,9 +84,31 @@ async function init() {
 
   // Setup event listeners
   setupEventListeners();
+  focusUnifiedInput({ force: true });
 
   isInitialized = true;
   await handlePendingMultiPanelAction();
+}
+
+function focusUnifiedInput({ force = false } = {}) {
+  const inputTextarea = document.getElementById('unified-input');
+  if (!inputTextarea) {
+    return;
+  }
+
+  const active = document.activeElement;
+  const shouldFocus = force || !active || active.tagName === 'IFRAME' || active === document.body;
+  if (!shouldFocus) {
+    return;
+  }
+
+  requestAnimationFrame(() => {
+    try {
+      inputTextarea.focus({ preventScroll: true });
+    } catch {
+      inputTextarea.focus();
+    }
+  });
 }
 
 async function getPendingMultiPanelAction() {
@@ -1385,12 +1407,7 @@ function setupEventListeners() {
   // the user can freely click into any AI page's input field.
   inputTextarea.addEventListener('blur', () => {
     if (loadingIframeCount > 0) {
-      requestAnimationFrame(() => {
-        const active = document.activeElement;
-        if (!active || active.tagName === 'IFRAME' || active === document.body) {
-          inputTextarea.focus();
-        }
-      });
+      focusUnifiedInput();
     }
   });
 

--- a/tests/e2e/focus-protection.e2e.test.js
+++ b/tests/e2e/focus-protection.e2e.test.js
@@ -37,6 +37,19 @@ test.describe('Focus Protection E2E', () => {
     await browser.close().catch(() => {});
   });
 
+  test('Test 0: Unified input should be focused when page first opens', async () => {
+    await page.waitForTimeout(120);
+
+    let activeId = await page.evaluate(() => window.getActiveElementId());
+    expect(activeId).toBe('unified-input');
+
+    await page.evaluate(() => window.addFocusStealingIframe(100));
+    await page.waitForTimeout(800);
+
+    activeId = await page.evaluate(() => window.getActiveElementId());
+    expect(activeId).toBe('unified-input');
+  });
+
   test('Test 1: Focus should stay on textarea when iframe steals focus during loading', async () => {
     await page.click('#unified-input');
     await page.waitForTimeout(100);

--- a/tests/e2e/test-focus-protection.html
+++ b/tests/e2e/test-focus-protection.html
@@ -25,17 +25,30 @@
     // === Loading counter (same as multi-panel.js) ===
     let loadingIframeCount = 0;
 
+    function focusUnifiedInput(options = {}) {
+      const force = Boolean(options.force);
+      const active = document.activeElement;
+      const shouldFocus = force || !active || active.tagName === 'IFRAME' || active === document.body;
+      if (!shouldFocus) {
+        return;
+      }
+
+      requestAnimationFrame(() => {
+        try {
+          inputTextarea.focus({ preventScroll: true });
+        } catch {
+          inputTextarea.focus();
+        }
+      });
+    }
+
     // === Focus protection logic (identical to multi-panel.js) ===
     inputTextarea.addEventListener('blur', () => {
       if (loadingIframeCount > 0) {
-        requestAnimationFrame(() => {
-          const active = document.activeElement;
-          if (!active || active.tagName === 'IFRAME' || active === document.body) {
-            inputTextarea.focus();
-          }
-        });
+        focusUnifiedInput();
       }
     });
+    focusUnifiedInput({ force: true });
     // === End focus protection logic ===
 
     // Expose functions for Playwright test


### PR DESCRIPTION
## Summary
- ensure unified input is focused when multi-panel page initializes
- reuse a shared focus helper to keep focus on unified input while provider iframes are still loading
- align focus-protection e2e harness with production logic and add an initial-focus test

## Testing
- npm test -- --run tests/layout-auto-adjust.test.js
- npx playwright test tests/e2e/focus-protection.e2e.test.js