### PR TITLE
fix: stabilize icon rendering on initial load

### DIFF
--- a/multi-panel/multi-panel.html
+++ b/multi-panel/multi-panel.html
@@ -7,7 +7,11 @@
   <link rel="stylesheet" href="multi-panel.css">
 
   <!-- Material Symbols font -->
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
+  <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+  <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet">
 
   <!-- DNS prefetch and preconnect for faster loading -->
   <link rel="dns-prefetch" href="https://chatgpt.com">


### PR DESCRIPTION
## Summary
- switch Material Symbols in multi-panel page from `display=swap` to `display=block`
- add `dns-prefetch` and `preconnect` for Google Fonts domains used by icon font
- reduce first-load icon fallback rendering that looks like garbled symbols

## Testing
- npm test -- --run tests/layout-auto-adjust.test.js
