### PR TITLE
docs: add localized readmes and update store link

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,153 @@
+# Panelize
+
+<p align="center">
+  <a href="README.md"><strong>English</strong></a> |
+  <a href="README.zh-CN.md"><strong>简体中文</strong></a> |
+  <a href="README.ja.md"><strong>日本語</strong></a>
+</p>
+
+<p align="center">
+  <img src="assets/screenshots/panelize-marquee.png" alt="Panelize - All Your AI Assistants. One Window." width="700">
+</p>
+
+<p align="center">
+  <strong>タブ切り替えをやめて、複数 AI の回答を1画面で比較。</strong>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.0.2-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
+  <img src="https://img.shields.io/badge/languages-10-brightgreen.svg" alt="Languages">
+  <img src="https://img.shields.io/badge/Chrome-114+-4285F4.svg" alt="Chrome">
+  <img src="https://img.shields.io/badge/Edge-114+-0078D7.svg" alt="Edge">
+</p>
+
+---
+
+## Panelize とは？
+
+同じプロンプトを複数の AI タブに貼り付けて比較する作業を、1つの画面にまとめる拡張機能です。
+
+**1つの入力で、複数 AI の回答を同時に比較できます。**
+
+<p align="center">
+  <img src="assets/screenshots/main-panel.png" alt="Panelize Main Interface" width="800">
+</p>
+
+---
+
+## 主な機能
+
+### 1回の入力で同時送信
+
+統一入力欄から ChatGPT / Claude / Gemini / Grok / DeepSeek / Kimi / Google AI Mode へ同時に送信できます。
+
+### 柔軟なレイアウト
+
+15種類のレイアウトを用意。2モデルの比較から多モデルの検証まで対応します。
+
+<p align="center">
+  <img src="assets/screenshots/select-layout.png" alt="Layout Selection" width="600">
+</p>
+
+### 初期設定ほぼ不要
+
+API キー不要。通常どおり各 AI サービスにログインしていれば利用できます。
+
+### Prompt Library
+
+よく使うプロンプトを保存して再利用可能。`{topic}` などの変数にも対応。
+
+### プライバシー重視
+
+- データはブラウザ内に保存
+- トラッキングなし、分析なし
+- オープンソース
+
+---
+
+## 対応 AI プロバイダー
+
+- ChatGPT
+- Claude
+- Gemini
+- Grok
+- DeepSeek
+- Kimi
+- Google AI Mode
+
+<p align="center">
+  <img src="assets/screenshots/settings.png" alt="Settings & Providers" width="700">
+</p>
+
+---
+
+## インストール
+
+### Chrome Web Store（推奨）
+
+1. [Chrome Web Store ページ](https://chromewebstore.google.com/detail/panelize/iokalaafkmjffolodkkgbbccmofbglii) を開く
+2. **Add to Chrome** をクリック
+3. インストール後、`Cmd/Ctrl + Shift + E` で Panelize を開く
+
+> **Edge でも利用可能：** Chrome Web Store からそのままインストールできます。
+
+<details>
+<summary><strong>手動インストール（開発者向け）</strong></summary>
+
+1. このリポジトリのソースコードをダウンロード
+2. `chrome://extensions/`（または `edge://extensions/`）を開く
+3. デベロッパーモードを有効化
+4. 「パッケージ化されていない拡張機能を読み込む」でフォルダを選択
+
+</details>
+
+---
+
+## クイックスタート
+
+1. **各 AI サービスへログイン**（通常のブラウザタブで事前ログイン）
+2. **`Cmd/Ctrl + Shift + E` を押す**
+3. **レイアウトを選ぶ**
+4. **入力して送信**（全パネルへ同時反映）
+
+---
+
+## キーボードショートカット
+
+| 操作 | ショートカット |
+|------|----------------|
+| Panelize を開く | `Cmd/Ctrl + Shift + E` |
+| Prompt Library を開く | `Cmd/Ctrl + Shift + L` |
+
+`chrome://extensions/shortcuts` で変更できます。
+
+---
+
+## トラブルシューティング
+
+**ログイン画面が表示される場合**
+→ 先に通常タブで対象サービスへログインし、Panelize を再読み込みしてください。
+
+**ショートカットが動作しない場合**
+→ `chrome://extensions/shortcuts` で競合を確認してください。
+
+**サポートが必要な場合**
+→ [Issue を作成](https://github.com/Manho/Panelize/issues)
+
+---
+
+## コントリビューション
+
+コントリビューション歓迎です。
+
+- 🐛 バグ報告
+- 💡 機能提案
+- 🌍 翻訳の改善
+- 🔧 Pull Request
+
+---
+
+## License
+
+MIT License。詳細は [LICENSE](LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Panelize
 
 <p align="center">
+  <a href="README.md"><strong>English</strong></a> |
+  <a href="README.zh-CN.md"><strong>简体中文</strong></a> |
+  <a href="README.ja.md"><strong>日本語</strong></a>
+</p>
+
+<p align="center">
   <img src="assets/screenshots/panelize-marquee.png" alt="Panelize - All Your AI Assistants. One Window." width="700">
 </p>
 
@@ -9,7 +15,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.0.0-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.0.2-blue.svg" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
   <img src="https://img.shields.io/badge/languages-10-brightgreen.svg" alt="Languages">
   <img src="https://img.shields.io/badge/Chrome-114+-4285F4.svg" alt="Chrome">
@@ -86,7 +92,7 @@ Save your best prompts and reuse them across all providers. Supports variables l
 
 ### Chrome Web Store (Recommended)
 
-1. Visit the [Chrome Web Store](link-coming-soon) page
+1. Visit the [Chrome Web Store](https://chromewebstore.google.com/detail/panelize/iokalaafkmjffolodkkgbbccmofbglii) page
 2. Click **"Add to Chrome"**
 3. Done! Press `Cmd/Ctrl + Shift + E` to open Panelize
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,153 @@
+# Panelize
+
+<p align="center">
+  <a href="README.md"><strong>English</strong></a> |
+  <a href="README.zh-CN.md"><strong>简体中文</strong></a> |
+  <a href="README.ja.md"><strong>日本語</strong></a>
+</p>
+
+<p align="center">
+  <img src="assets/screenshots/panelize-marquee.png" alt="Panelize - All Your AI Assistants. One Window." width="700">
+</p>
+
+<p align="center">
+  <strong>告别反复切换标签页，一次提问并排对比多个 AI 回答。</strong>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.0.2-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
+  <img src="https://img.shields.io/badge/languages-10-brightgreen.svg" alt="Languages">
+  <img src="https://img.shields.io/badge/Chrome-114+-4285F4.svg" alt="Chrome">
+  <img src="https://img.shields.io/badge/Edge-114+-0078D7.svg" alt="Edge">
+</p>
+
+---
+
+## 为什么选择 Panelize？
+
+还在把同一个 Prompt 复制到多个 AI 标签页里逐个比较吗？
+
+**Panelize 让你在一个窗口里，一次发送，直接横向对比多个 AI 的答案。**
+
+<p align="center">
+  <img src="assets/screenshots/main-panel.png" alt="Panelize 主界面" width="800">
+</p>
+
+---
+
+## 核心功能
+
+### 一次提问，同时对比
+
+在统一输入框中输入一次内容，就能同时发送到 ChatGPT、Claude、Gemini、Grok、DeepSeek、Kimi、Google AI Mode。
+
+### 灵活布局
+
+支持 15 种布局。快速双模型对比可用 1×2，深入分析可用 2×2 或更多。
+
+<p align="center">
+  <img src="assets/screenshots/select-layout.png" alt="布局选择" width="600">
+</p>
+
+### 零配置
+
+不需要 API Key，也不需要额外账号。你在浏览器里登录过对应平台即可使用。
+
+### Prompt Library
+
+可保存常用提示词，并支持 `{topic}` 这类变量占位符，复用更高效。
+
+### 隐私优先
+
+- 数据保留在本地浏览器
+- 无追踪、无埋点、无数据上传
+- 完全开源，可自行审阅代码
+
+---
+
+## 支持的 AI 平台
+
+- ChatGPT
+- Claude
+- Gemini
+- Grok
+- DeepSeek
+- Kimi
+- Google AI Mode
+
+<p align="center">
+  <img src="assets/screenshots/settings.png" alt="设置与平台管理" width="700">
+</p>
+
+---
+
+## 安装
+
+### Chrome Web Store（推荐）
+
+1. 打开 [Chrome Web Store 页面](https://chromewebstore.google.com/detail/panelize/iokalaafkmjffolodkkgbbccmofbglii)
+2. 点击 **Add to Chrome**
+3. 安装完成后按 `Cmd/Ctrl + Shift + E` 打开 Panelize
+
+> **Edge 也可用：** 可直接从 Chrome Web Store 安装。
+
+<details>
+<summary><strong>手动安装（开发者）</strong></summary>
+
+1. 下载本仓库源码
+2. 打开 `chrome://extensions/`（或 `edge://extensions/`）
+3. 开启“开发者模式”
+4. 点击“加载已解压的扩展程序”，选择项目目录
+
+</details>
+
+---
+
+## 快速开始
+
+1. **先登录各平台账号**：先在普通网页标签页登录 ChatGPT / Claude 等
+2. **按 `Cmd/Ctrl + Shift + E`**：打开 Panelize
+3. **选择布局**：按需求选择面板数量与布局
+4. **输入并发送**：一次发送到所有面板
+
+---
+
+## 快捷键
+
+| 操作 | 快捷键 |
+|------|--------|
+| 打开 Panelize | `Cmd/Ctrl + Shift + E` |
+| 打开 Prompt Library | `Cmd/Ctrl + Shift + L` |
+
+可在 `chrome://extensions/shortcuts` 自定义。
+
+---
+
+## 常见问题
+
+**AI 页面显示登录状态？**
+→ 先在普通标签页登录该平台，再刷新 Panelize。
+
+**快捷键无效？**
+→ 到 `chrome://extensions/shortcuts` 检查冲突。
+
+**需要帮助？**
+→ [提交 Issue](https://github.com/Manho/Panelize/issues)
+
+---
+
+## 贡献
+
+欢迎反馈与贡献：
+
+- 🐛 提交 Bug
+- 💡 提出功能建议
+- 🌍 参与更多语言翻译
+- 🔧 提交 Pull Request
+
+---
+
+## License
+
+MIT License，详见 [LICENSE](LICENSE)。


### PR DESCRIPTION
## Summary
- update README Chrome Web Store link to the new published URL
- add language switch links at the top of README (English / 简体中文 / 日本語)
- add `README.zh-CN.md` and `README.ja.md` for localized documentation
- sync README version badge to `1.0.2`

## Notes
- `.ccmanager.json` remains local-only and is not included in this PR
