### PR TITLE
fix: keep unified input focused during send all

### DIFF
--- a/content-scripts/text-injection-all-providers.js
+++ b/content-scripts/text-injection-all-providers.js
@@ -13,8 +13,10 @@
   const CHATGPT_STOP_BUTTON_SELECTOR = 'button[data-testid="stop-button"]';
   const CHATGPT_SEND_TRACKING_IDLE_DELAY_MS = 800;
   const CHATGPT_SEND_TRACKING_NO_BUSY_TIMEOUT_MS = 2000;
+  const MULTI_PANEL_USER_INTERACTION_TRACKING_TIMEOUT_MS = 90000;
   let googleSearchReplaceOnNextFill = true;
   let chatgptSendTracking = null;
+  let multiPanelUserInteractionTracking = null;
 
   // Provider-specific selectors
   const PROVIDER_SELECTORS = {
@@ -326,7 +328,7 @@
       : GOOGLE_AI_INPUT_SELECTORS;
   }
 
-  function postMultiPanelProviderStatus(type, requestId, phase) {
+  function postMultiPanelProviderStatus(type, requestId, phase, provider = detectProvider()) {
     if (!requestId || window.parent === window) {
       return;
     }
@@ -334,10 +336,75 @@
     window.parent.postMessage({
       type,
       requestId,
-      provider: 'chatgpt',
+      provider,
       phase,
       context: MULTI_PANEL_PROVIDER_STATUS_CONTEXT
     }, '*');
+  }
+
+  function stopMultiPanelUserInteractionTracking() {
+    const tracking = multiPanelUserInteractionTracking;
+    if (!tracking) {
+      return;
+    }
+
+    if (typeof tracking.timeoutId === 'number') {
+      clearTimeout(tracking.timeoutId);
+    }
+
+    if (tracking.interactionHandler) {
+      document.removeEventListener('pointerdown', tracking.interactionHandler, true);
+      document.removeEventListener('keydown', tracking.interactionHandler, true);
+    }
+
+    multiPanelUserInteractionTracking = null;
+  }
+
+  function startMultiPanelUserInteractionTracking(requestId, provider = detectProvider()) {
+    if (!requestId || !provider) {
+      return;
+    }
+
+    stopMultiPanelUserInteractionTracking();
+
+    const tracking = {
+      requestId,
+      provider,
+      timeoutId: null,
+      interactionHandler: null
+    };
+
+    tracking.interactionHandler = (event) => {
+      if (multiPanelUserInteractionTracking !== tracking || !event.isTrusted) {
+        return;
+      }
+
+      postMultiPanelProviderStatus(
+        PANELIZE_PROVIDER_USER_INTERACTION,
+        tracking.requestId,
+        'user-interaction',
+        tracking.provider
+      );
+
+      if (tracking.provider === 'chatgpt' && chatgptSendTracking?.requestId === tracking.requestId) {
+        stopChatgptSendTracking();
+      }
+
+      stopMultiPanelUserInteractionTracking();
+    };
+
+    document.addEventListener('pointerdown', tracking.interactionHandler, true);
+    document.addEventListener('keydown', tracking.interactionHandler, true);
+
+    tracking.timeoutId = setTimeout(() => {
+      if (multiPanelUserInteractionTracking !== tracking) {
+        return;
+      }
+
+      stopMultiPanelUserInteractionTracking();
+    }, MULTI_PANEL_USER_INTERACTION_TRACKING_TIMEOUT_MS);
+
+    multiPanelUserInteractionTracking = tracking;
   }
 
   function findChatgptBusyButton() {
@@ -368,16 +435,11 @@
       clearTimeout(tracking.noBusyTimerId);
     }
 
-    if (tracking.interactionHandler) {
-      document.removeEventListener('pointerdown', tracking.interactionHandler, true);
-      document.removeEventListener('keydown', tracking.interactionHandler, true);
-    }
-
     const { requestId, phase } = tracking;
     chatgptSendTracking = null;
 
     if (reportIdle) {
-      postMultiPanelProviderStatus(PANELIZE_PROVIDER_IDLE, requestId, phase);
+      postMultiPanelProviderStatus(PANELIZE_PROVIDER_IDLE, requestId, phase, 'chatgpt');
     }
   }
 
@@ -400,7 +462,7 @@
 
       if (tracking.phase !== 'busy') {
         tracking.phase = 'busy';
-        postMultiPanelProviderStatus(PANELIZE_PROVIDER_BUSY, tracking.requestId, tracking.phase);
+        postMultiPanelProviderStatus(PANELIZE_PROVIDER_BUSY, tracking.requestId, tracking.phase, 'chatgpt');
       }
       return;
     }
@@ -438,21 +500,8 @@
       phase: 'pending',
       observer: null,
       idleTimerId: null,
-      noBusyTimerId: null,
-      interactionHandler: null
+      noBusyTimerId: null
     };
-
-    tracking.interactionHandler = (event) => {
-      if (chatgptSendTracking !== tracking || !event.isTrusted) {
-        return;
-      }
-
-      postMultiPanelProviderStatus(PANELIZE_PROVIDER_USER_INTERACTION, tracking.requestId, tracking.phase);
-      stopChatgptSendTracking();
-    };
-
-    document.addEventListener('pointerdown', tracking.interactionHandler, true);
-    document.addEventListener('keydown', tracking.interactionHandler, true);
 
     const observerTarget = document.body || getChatgptComposerRoot();
     if (observerTarget) {
@@ -1075,6 +1124,12 @@
     console.log(`[Image Injection] Injecting ${images.length} images to ${provider}`);
 
     try {
+      if (autoSubmit && requestId) {
+        startMultiPanelUserInteractionTracking(requestId, provider);
+      } else {
+        stopMultiPanelUserInteractionTracking();
+      }
+
       if (provider === 'chatgpt' && autoSubmit && requestId) {
         startChatgptSendTracking(requestId);
       }
@@ -1457,6 +1512,7 @@
     // Handle CLEAR_INPUT messages
     if (event.data.type === 'CLEAR_INPUT' && event.data.context === 'multi-panel') {
       const provider = detectProvider();
+      stopMultiPanelUserInteractionTracking();
       if (provider === 'chatgpt') {
         stopChatgptSendTracking();
       }
@@ -1535,6 +1591,11 @@
         const providerMode = provider === 'google'
           ? normalizeGoogleProviderMode(event.data.providerMode)
           : null;
+        if (event.data.requestId) {
+          startMultiPanelUserInteractionTracking(event.data.requestId, provider);
+        } else {
+          stopMultiPanelUserInteractionTracking();
+        }
         if (provider === 'chatgpt' && event.data.requestId) {
           startChatgptSendTracking(event.data.requestId);
         }
@@ -1547,6 +1608,7 @@
     // Handle NEW_CHAT messages (create new chat)
     if (event.data.type === 'NEW_CHAT' && event.data.context === 'multi-panel') {
       const provider = detectProvider();
+      stopMultiPanelUserInteractionTracking();
       if (provider === 'chatgpt') {
         stopChatgptSendTracking();
       }
@@ -1608,10 +1670,16 @@
 
     if (provider === 'chatgpt') {
       if (shouldAutoSubmit && event.data.requestId) {
+        startMultiPanelUserInteractionTracking(event.data.requestId, provider);
         startChatgptSendTracking(event.data.requestId);
       } else {
+        stopMultiPanelUserInteractionTracking();
         stopChatgptSendTracking();
       }
+    } else if (shouldAutoSubmit && event.data.requestId) {
+      startMultiPanelUserInteractionTracking(event.data.requestId, provider);
+    } else {
+      stopMultiPanelUserInteractionTracking();
     }
 
     if (provider === 'google') {

--- a/content-scripts/text-injection-all-providers.js
+++ b/content-scripts/text-injection-all-providers.js
@@ -6,7 +6,15 @@
 
   const GOOGLE_PROVIDER_MODE_AI = 'ai';
   const GOOGLE_PROVIDER_MODE_SEARCH = 'search';
+  const MULTI_PANEL_PROVIDER_STATUS_CONTEXT = 'multi-panel-provider-status';
+  const PANELIZE_PROVIDER_BUSY = 'PANELIZE_PROVIDER_BUSY';
+  const PANELIZE_PROVIDER_IDLE = 'PANELIZE_PROVIDER_IDLE';
+  const PANELIZE_PROVIDER_USER_INTERACTION = 'PANELIZE_PROVIDER_USER_INTERACTION';
+  const CHATGPT_STOP_BUTTON_SELECTOR = 'button[data-testid="stop-button"]';
+  const CHATGPT_SEND_TRACKING_IDLE_DELAY_MS = 800;
+  const CHATGPT_SEND_TRACKING_NO_BUSY_TIMEOUT_MS = 2000;
   let googleSearchReplaceOnNextFill = true;
+  let chatgptSendTracking = null;
 
   // Provider-specific selectors
   const PROVIDER_SELECTORS = {
@@ -316,6 +324,169 @@
     return normalizeGoogleProviderMode(mode) === GOOGLE_PROVIDER_MODE_SEARCH
       ? GOOGLE_SEARCH_INPUT_SELECTORS
       : GOOGLE_AI_INPUT_SELECTORS;
+  }
+
+  function postMultiPanelProviderStatus(type, requestId, phase) {
+    if (!requestId || window.parent === window) {
+      return;
+    }
+
+    window.parent.postMessage({
+      type,
+      requestId,
+      provider: 'chatgpt',
+      phase,
+      context: MULTI_PANEL_PROVIDER_STATUS_CONTEXT
+    }, '*');
+  }
+
+  function findChatgptBusyButton() {
+    return document.querySelector(CHATGPT_STOP_BUTTON_SELECTOR);
+  }
+
+  function getChatgptComposerRoot() {
+    return document.querySelector('form[data-type="unified-composer"]') ||
+      document.querySelector('#prompt-textarea')?.closest('form') ||
+      document.body;
+  }
+
+  function stopChatgptSendTracking({ reportIdle = false } = {}) {
+    const tracking = chatgptSendTracking;
+    if (!tracking) {
+      return;
+    }
+
+    if (tracking.observer) {
+      tracking.observer.disconnect();
+    }
+
+    if (typeof tracking.idleTimerId === 'number') {
+      clearTimeout(tracking.idleTimerId);
+    }
+
+    if (typeof tracking.noBusyTimerId === 'number') {
+      clearTimeout(tracking.noBusyTimerId);
+    }
+
+    if (tracking.interactionHandler) {
+      document.removeEventListener('pointerdown', tracking.interactionHandler, true);
+      document.removeEventListener('keydown', tracking.interactionHandler, true);
+    }
+
+    const { requestId, phase } = tracking;
+    chatgptSendTracking = null;
+
+    if (reportIdle) {
+      postMultiPanelProviderStatus(PANELIZE_PROVIDER_IDLE, requestId, phase);
+    }
+  }
+
+  function evaluateChatgptSendTrackingState() {
+    const tracking = chatgptSendTracking;
+    if (!tracking) {
+      return;
+    }
+
+    if (findChatgptBusyButton()) {
+      if (typeof tracking.noBusyTimerId === 'number') {
+        clearTimeout(tracking.noBusyTimerId);
+        tracking.noBusyTimerId = null;
+      }
+
+      if (typeof tracking.idleTimerId === 'number') {
+        clearTimeout(tracking.idleTimerId);
+        tracking.idleTimerId = null;
+      }
+
+      if (tracking.phase !== 'busy') {
+        tracking.phase = 'busy';
+        postMultiPanelProviderStatus(PANELIZE_PROVIDER_BUSY, tracking.requestId, tracking.phase);
+      }
+      return;
+    }
+
+    if (tracking.phase !== 'busy' || typeof tracking.idleTimerId === 'number') {
+      return;
+    }
+
+    tracking.idleTimerId = setTimeout(() => {
+      const currentTracking = chatgptSendTracking;
+      if (!currentTracking || currentTracking.requestId !== tracking.requestId) {
+        return;
+      }
+
+      currentTracking.idleTimerId = null;
+      if (findChatgptBusyButton()) {
+        evaluateChatgptSendTrackingState();
+        return;
+      }
+
+      currentTracking.phase = 'idle';
+      stopChatgptSendTracking({ reportIdle: true });
+    }, CHATGPT_SEND_TRACKING_IDLE_DELAY_MS);
+  }
+
+  function startChatgptSendTracking(requestId) {
+    if (!requestId) {
+      return;
+    }
+
+    stopChatgptSendTracking();
+
+    const tracking = {
+      requestId,
+      phase: 'pending',
+      observer: null,
+      idleTimerId: null,
+      noBusyTimerId: null,
+      interactionHandler: null
+    };
+
+    tracking.interactionHandler = (event) => {
+      if (chatgptSendTracking !== tracking || !event.isTrusted) {
+        return;
+      }
+
+      postMultiPanelProviderStatus(PANELIZE_PROVIDER_USER_INTERACTION, tracking.requestId, tracking.phase);
+      stopChatgptSendTracking();
+    };
+
+    document.addEventListener('pointerdown', tracking.interactionHandler, true);
+    document.addEventListener('keydown', tracking.interactionHandler, true);
+
+    const observerTarget = document.body || getChatgptComposerRoot();
+    if (observerTarget) {
+      tracking.observer = new MutationObserver(() => {
+        if (chatgptSendTracking !== tracking) {
+          return;
+        }
+
+        if (typeof tracking.idleTimerId === 'number' && findChatgptBusyButton()) {
+          clearTimeout(tracking.idleTimerId);
+          tracking.idleTimerId = null;
+        }
+
+        evaluateChatgptSendTrackingState();
+      });
+
+      tracking.observer.observe(observerTarget, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['data-testid', 'aria-label', 'disabled', 'aria-disabled']
+      });
+    }
+
+    tracking.noBusyTimerId = setTimeout(() => {
+      if (chatgptSendTracking !== tracking || tracking.phase !== 'pending') {
+        return;
+      }
+
+      stopChatgptSendTracking();
+    }, CHATGPT_SEND_TRACKING_NO_BUSY_TIMEOUT_MS);
+
+    chatgptSendTracking = tracking;
+    evaluateChatgptSendTrackingState();
   }
 
   function findGoogleInput(mode) {
@@ -868,7 +1039,7 @@
 
   // Handle image injection message
   async function handleImageInjection(event) {
-    const { text, images, autoSubmit } = event.data;
+    const { text, images, autoSubmit, requestId } = event.data;
     const provider = detectProvider();
     const providerMode = provider === 'google'
       ? normalizeGoogleProviderMode(event.data.providerMode)
@@ -904,6 +1075,10 @@
     console.log(`[Image Injection] Injecting ${images.length} images to ${provider}`);
 
     try {
+      if (provider === 'chatgpt' && autoSubmit && requestId) {
+        startChatgptSendTracking(requestId);
+      }
+
       // Inject images first
       for (const image of images) {
         await injectSingleImage(provider, image);
@@ -1282,6 +1457,9 @@
     // Handle CLEAR_INPUT messages
     if (event.data.type === 'CLEAR_INPUT' && event.data.context === 'multi-panel') {
       const provider = detectProvider();
+      if (provider === 'chatgpt') {
+        stopChatgptSendTracking();
+      }
       if (provider) {
         const providerMode = provider === 'google'
           ? normalizeGoogleProviderMode(event.data.providerMode)
@@ -1357,6 +1535,9 @@
         const providerMode = provider === 'google'
           ? normalizeGoogleProviderMode(event.data.providerMode)
           : null;
+        if (provider === 'chatgpt' && event.data.requestId) {
+          startChatgptSendTracking(event.data.requestId);
+        }
         console.log('[Text Injection] Triggering send for', provider);
         clickSendButton(provider, providerMode);
       }
@@ -1366,6 +1547,9 @@
     // Handle NEW_CHAT messages (create new chat)
     if (event.data.type === 'NEW_CHAT' && event.data.context === 'multi-panel') {
       const provider = detectProvider();
+      if (provider === 'chatgpt') {
+        stopChatgptSendTracking();
+      }
       const providerMode = provider === 'google'
         ? normalizeGoogleProviderMode(event.data.providerMode)
         : null;
@@ -1421,6 +1605,14 @@
     const providerMode = provider === 'google'
       ? normalizeGoogleProviderMode(event.data.providerMode)
       : null;
+
+    if (provider === 'chatgpt') {
+      if (shouldAutoSubmit && event.data.requestId) {
+        startChatgptSendTracking(event.data.requestId);
+      } else {
+        stopChatgptSendTracking();
+      }
+    }
 
     if (provider === 'google') {
       const success = handleGoogleTextInjection(text, shouldAutoSubmit, providerMode);

--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -36,6 +36,8 @@ let uploadedImages = []; // Array of uploaded images { id, name, type, dataUrl }
 let loadingIframeCount = 0; // Track iframes still loading, used for focus protection
 let newChatFocusRestoreTimerIds = [];
 let isRestoringFocusAfterNewChat = false;
+let sendFocusRestoreTimerIds = [];
+let isRestoringFocusAfterSend = false;
 let currentGoogleProviderMode = DEFAULT_GOOGLE_PROVIDER_MODE;
 
 // 提示词编辑器状态
@@ -121,6 +123,10 @@ function focusUnifiedInput({ force = false } = {}) {
       inputTextarea.focus();
     }
   });
+}
+
+function shouldPreserveUnifiedInputFocus() {
+  return loadingIframeCount > 0 || isRestoringFocusAfterNewChat || isRestoringFocusAfterSend;
 }
 
 function isGoogleProvider(providerId) {
@@ -326,12 +332,26 @@ function cancelUnifiedInputFocusRestore() {
   isRestoringFocusAfterNewChat = false;
 }
 
+function cancelUnifiedInputFocusRestoreAfterSend() {
+  sendFocusRestoreTimerIds.forEach(timerId => clearTimeout(timerId));
+  sendFocusRestoreTimerIds = [];
+  isRestoringFocusAfterSend = false;
+}
+
 function isUnifiedInputOrNewChatControl(target) {
   if (!(target instanceof Element)) {
     return false;
   }
 
   return Boolean(target.closest('#unified-input, #new-chat-btn'));
+}
+
+function isUnifiedInputOrSendControl(target) {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  return Boolean(target.closest('#unified-input, #send-all-btn'));
 }
 
 function restoreUnifiedInputFocusAfterNewChat() {
@@ -353,6 +373,28 @@ function restoreUnifiedInputFocusAfterNewChat() {
     }, delay);
 
     newChatFocusRestoreTimerIds.push(timerId);
+  });
+}
+
+function restoreUnifiedInputFocusAfterSend() {
+  cancelUnifiedInputFocusRestoreAfterSend();
+  isRestoringFocusAfterSend = true;
+
+  const restoreDelays = [0, 80, 200, 400, 800, 1500, 2500, 4000, 6000, 8000, 10000, 12000];
+  restoreDelays.forEach((delay, index) => {
+    const timerId = setTimeout(() => {
+      if (!isRestoringFocusAfterSend) {
+        return;
+      }
+
+      focusUnifiedInput({ force: true });
+
+      if (index === restoreDelays.length - 1) {
+        cancelUnifiedInputFocusRestoreAfterSend();
+      }
+    }, delay);
+
+    sendFocusRestoreTimerIds.push(timerId);
   });
 }
 
@@ -966,6 +1008,10 @@ async function broadcastMessage(text, autoSubmit = true) {
   // This gives users a chance to verify content before sending
   const shouldAutoSubmit = hasImages ? false : autoSubmit;
 
+  if (shouldAutoSubmit) {
+    restoreUnifiedInputFocusAfterSend();
+  }
+
   try {
     // Disable buttons during send
     sendBtn.disabled = true;
@@ -1214,6 +1260,7 @@ async function triggerSendButtons() {
   const statusEl = document.getElementById('send-status');
 
   try {
+    restoreUnifiedInputFocusAfterSend();
     sendBtn.disabled = true;
     fillBtn.disabled = true;
     statusEl.textContent = 'Sending...';
@@ -1622,8 +1669,16 @@ function setupEventListeners() {
     broadcastMessage(input.value, false);
   });
 
+  const sendAllBtn = document.getElementById('send-all-btn');
+  const preserveSendAllButtonFocus = (event) => {
+    event.preventDefault();
+  };
+
+  sendAllBtn.addEventListener('pointerdown', preserveSendAllButtonFocus);
+  sendAllBtn.addEventListener('mousedown', preserveSendAllButtonFocus);
+
   // Send All button (fill + auto-send)
-  document.getElementById('send-all-btn').addEventListener('click', () => {
+  sendAllBtn.addEventListener('click', () => {
     const input = document.getElementById('unified-input');
     broadcastMessage(input.value, true);
   });
@@ -1663,10 +1718,9 @@ function setupEventListeners() {
   });
 
   // Prevent iframes from stealing focus from unified input during page load.
-  // Only active while iframes are still loading. Once all panels are loaded,
-  // the user can freely click into any AI page's input field.
+  // Also active during post-send and post-new-chat restore windows.
   inputTextarea.addEventListener('blur', () => {
-    if (loadingIframeCount > 0) {
+    if (shouldPreserveUnifiedInputFocus()) {
       focusUnifiedInput();
     }
   });
@@ -1688,6 +1742,24 @@ function setupEventListeners() {
   document.addEventListener('click', cancelNewChatFocusRestoreOnUserIntent, true);
   document.addEventListener('focusin', cancelNewChatFocusRestoreOnUserIntent, true);
   document.addEventListener('keydown', cancelNewChatFocusRestoreOnUserIntent, true);
+
+  const cancelSendFocusRestoreOnUserIntent = (event) => {
+    if (!isRestoringFocusAfterSend) {
+      return;
+    }
+
+    if (isUnifiedInputOrSendControl(event.target)) {
+      return;
+    }
+
+    cancelUnifiedInputFocusRestoreAfterSend();
+  };
+
+  document.addEventListener('pointerdown', cancelSendFocusRestoreOnUserIntent, true);
+  document.addEventListener('mousedown', cancelSendFocusRestoreOnUserIntent, true);
+  document.addEventListener('click', cancelSendFocusRestoreOnUserIntent, true);
+  document.addEventListener('focusin', cancelSendFocusRestoreOnUserIntent, true);
+  document.addEventListener('keydown', cancelSendFocusRestoreOnUserIntent, true);
 
   // Layout modal outside click
   document.getElementById('layout-modal').addEventListener('click', (e) => {

--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -38,6 +38,11 @@ let newChatFocusRestoreTimerIds = [];
 let isRestoringFocusAfterNewChat = false;
 let sendFocusRestoreTimerIds = [];
 let isRestoringFocusAfterSend = false;
+let activeSendFocusRequestId = null;
+let sendFocusRequestCounter = 0;
+let sendFocusActivePanelIds = new Set();
+let sendFocusBusyDetectionTimeoutIds = new Map();
+let sendFocusHardTimeoutIds = new Map();
 let currentGoogleProviderMode = DEFAULT_GOOGLE_PROVIDER_MODE;
 
 // 提示词编辑器状态
@@ -51,6 +56,13 @@ let isPopupWindow = false;   // 当前窗口是否为弹出窗口
 const DEFAULT_PROVIDERS = ['chatgpt', 'claude', 'gemini', 'grok', 'deepseek', 'kimi', 'google'];
 const MAX_PANELS = 7;
 const PENDING_MULTI_PANEL_ACTION_KEY = 'pendingMultiPanelAction';
+const SEND_FOCUS_RESTORE_DELAYS = [0, 80, 200, 400, 800, 1500, 2500, 4000, 6000, 8000, 10000, 12000];
+const SEND_FOCUS_NO_BUSY_TIMEOUT_MS = 2000;
+const SEND_FOCUS_HARD_TIMEOUT_MS = 90000;
+const MULTI_PANEL_PROVIDER_STATUS_CONTEXT = 'multi-panel-provider-status';
+const PANELIZE_PROVIDER_BUSY = 'PANELIZE_PROVIDER_BUSY';
+const PANELIZE_PROVIDER_IDLE = 'PANELIZE_PROVIDER_IDLE';
+const PANELIZE_PROVIDER_USER_INTERACTION = 'PANELIZE_PROVIDER_USER_INTERACTION';
 const LAYOUT_PANEL_COUNTS = {
   '1x1': 1,
   '1x2': 2,
@@ -131,6 +143,10 @@ function shouldPreserveUnifiedInputFocus() {
 
 function isGoogleProvider(providerId) {
   return providerId === 'google';
+}
+
+function isChatgptProvider(providerId) {
+  return providerId === 'chatgpt';
 }
 
 function getPanelProviderMode(panel) {
@@ -335,6 +351,12 @@ function cancelUnifiedInputFocusRestore() {
 function cancelUnifiedInputFocusRestoreAfterSend() {
   sendFocusRestoreTimerIds.forEach(timerId => clearTimeout(timerId));
   sendFocusRestoreTimerIds = [];
+  sendFocusBusyDetectionTimeoutIds.forEach(timerId => clearTimeout(timerId));
+  sendFocusBusyDetectionTimeoutIds.clear();
+  sendFocusHardTimeoutIds.forEach(timerId => clearTimeout(timerId));
+  sendFocusHardTimeoutIds.clear();
+  sendFocusActivePanelIds.clear();
+  activeSendFocusRequestId = null;
   isRestoringFocusAfterSend = false;
 }
 
@@ -376,26 +398,151 @@ function restoreUnifiedInputFocusAfterNewChat() {
   });
 }
 
-function restoreUnifiedInputFocusAfterSend() {
+function createSendFocusRequestId() {
+  sendFocusRequestCounter += 1;
+  return `send-focus-${Date.now()}-${sendFocusRequestCounter}`;
+}
+
+function clearSendFocusProviderTimeout(timeoutMap, panelId) {
+  const timerId = timeoutMap.get(panelId);
+  if (typeof timerId === 'number') {
+    clearTimeout(timerId);
+  }
+  timeoutMap.delete(panelId);
+}
+
+function maybeStopSendFocusRestore() {
+  if (sendFocusRestoreTimerIds.length > 0) {
+    return;
+  }
+
+  if (sendFocusActivePanelIds.size > 0) {
+    return;
+  }
+
+  cancelUnifiedInputFocusRestoreAfterSend();
+}
+
+function getChatgptPanelsWithFrames() {
+  return panels.filter(panel => (
+    isChatgptProvider(panel.providerId) &&
+    panel.iframe &&
+    panel.iframe.contentWindow
+  ));
+}
+
+function scheduleChatgptBusyDetectionTimeout(panel, requestId) {
+  clearSendFocusProviderTimeout(sendFocusBusyDetectionTimeoutIds, panel.id);
+
+  const timerId = setTimeout(() => {
+    if (activeSendFocusRequestId !== requestId) {
+      return;
+    }
+
+    sendFocusBusyDetectionTimeoutIds.delete(panel.id);
+  }, SEND_FOCUS_NO_BUSY_TIMEOUT_MS);
+
+  sendFocusBusyDetectionTimeoutIds.set(panel.id, timerId);
+}
+
+function scheduleChatgptHardTimeout(panelId, requestId) {
+  clearSendFocusProviderTimeout(sendFocusHardTimeoutIds, panelId);
+
+  const timerId = setTimeout(() => {
+    if (activeSendFocusRequestId !== requestId) {
+      return;
+    }
+
+    console.warn('[Multi-Panel] Releasing send focus protection after ChatGPT hard timeout:', panelId);
+    sendFocusActivePanelIds.delete(panelId);
+    sendFocusHardTimeoutIds.delete(panelId);
+    maybeStopSendFocusRestore();
+  }, SEND_FOCUS_HARD_TIMEOUT_MS);
+
+  sendFocusHardTimeoutIds.set(panelId, timerId);
+}
+
+function handleSendFocusProviderBusy(panel, requestId) {
+  if (activeSendFocusRequestId !== requestId) {
+    return;
+  }
+
+  clearSendFocusProviderTimeout(sendFocusBusyDetectionTimeoutIds, panel.id);
+  sendFocusActivePanelIds.add(panel.id);
+  isRestoringFocusAfterSend = true;
+  scheduleChatgptHardTimeout(panel.id, requestId);
+  focusUnifiedInput({ force: true });
+}
+
+function handleSendFocusProviderIdle(panel, requestId) {
+  if (activeSendFocusRequestId !== requestId) {
+    return;
+  }
+
+  clearSendFocusProviderTimeout(sendFocusBusyDetectionTimeoutIds, panel.id);
+  clearSendFocusProviderTimeout(sendFocusHardTimeoutIds, panel.id);
+  sendFocusActivePanelIds.delete(panel.id);
+  maybeStopSendFocusRestore();
+}
+
+function restoreUnifiedInputFocusAfterSend(trackedPanels = []) {
   cancelUnifiedInputFocusRestoreAfterSend();
   isRestoringFocusAfterSend = true;
+  activeSendFocusRequestId = createSendFocusRequestId();
 
-  const restoreDelays = [0, 80, 200, 400, 800, 1500, 2500, 4000, 6000, 8000, 10000, 12000];
-  restoreDelays.forEach((delay, index) => {
+  trackedPanels.forEach(panel => scheduleChatgptBusyDetectionTimeout(panel, activeSendFocusRequestId));
+
+  const requestId = activeSendFocusRequestId;
+  SEND_FOCUS_RESTORE_DELAYS.forEach((delay, index) => {
     const timerId = setTimeout(() => {
-      if (!isRestoringFocusAfterSend) {
+      if (!isRestoringFocusAfterSend || activeSendFocusRequestId !== requestId) {
         return;
       }
 
       focusUnifiedInput({ force: true });
 
-      if (index === restoreDelays.length - 1) {
-        cancelUnifiedInputFocusRestoreAfterSend();
+      if (index === SEND_FOCUS_RESTORE_DELAYS.length - 1) {
+        sendFocusRestoreTimerIds = [];
+        maybeStopSendFocusRestore();
       }
     }, delay);
 
     sendFocusRestoreTimerIds.push(timerId);
   });
+
+  return requestId;
+}
+
+function handleProviderStatusMessage(event) {
+  const data = event?.data;
+  if (!data || typeof data !== 'object') {
+    return;
+  }
+
+  if (data.context !== MULTI_PANEL_PROVIDER_STATUS_CONTEXT || !data.requestId) {
+    return;
+  }
+
+  const panel = panels.find(candidate => candidate.iframe?.contentWindow === event.source);
+  if (!panel || !isChatgptProvider(panel.providerId) || data.provider !== panel.providerId) {
+    return;
+  }
+
+  switch (data.type) {
+    case PANELIZE_PROVIDER_BUSY:
+      handleSendFocusProviderBusy(panel, data.requestId);
+      break;
+    case PANELIZE_PROVIDER_IDLE:
+      handleSendFocusProviderIdle(panel, data.requestId);
+      break;
+    case PANELIZE_PROVIDER_USER_INTERACTION:
+      if (data.requestId === activeSendFocusRequestId) {
+        cancelUnifiedInputFocusRestoreAfterSend();
+      }
+      break;
+    default:
+      break;
+  }
 }
 
 async function getPendingMultiPanelAction() {
@@ -1007,10 +1154,9 @@ async function broadcastMessage(text, autoSubmit = true) {
   // User needs to click "Send All" again to actually send
   // This gives users a chance to verify content before sending
   const shouldAutoSubmit = hasImages ? false : autoSubmit;
-
-  if (shouldAutoSubmit) {
-    restoreUnifiedInputFocusAfterSend();
-  }
+  const sendFocusRequestId = shouldAutoSubmit
+    ? restoreUnifiedInputFocusAfterSend(getChatgptPanelsWithFrames())
+    : null;
 
   try {
     // Disable buttons during send
@@ -1028,7 +1174,7 @@ async function broadcastMessage(text, autoSubmit = true) {
 
     // Send to all panels
     const panelResults = await Promise.allSettled(
-      panels.map(panel => sendToPanel(panel, text, imagesPayload, shouldAutoSubmit))
+      panels.map(panel => sendToPanel(panel, text, imagesPayload, shouldAutoSubmit, sendFocusRequestId))
     );
 
     // Count results (panels only)
@@ -1084,7 +1230,7 @@ async function broadcastMessage(text, autoSubmit = true) {
   }
 }
 
-async function sendToPanel(panel, text, images = [], autoSubmit = true) {
+async function sendToPanel(panel, text, images = [], autoSubmit = true, requestId = null) {
   return new Promise((resolve) => {
     try {
       if (!panel.iframe || !panel.iframe.contentWindow) {
@@ -1102,6 +1248,7 @@ async function sendToPanel(panel, text, images = [], autoSubmit = true) {
         text: text,
         images: images,
         autoSubmit: autoSubmit,
+        requestId: requestId,
         providerMode: getPanelProviderMode(panel),
         context: 'multi-panel'  // Identify this is from multi-panel
       }, '*');
@@ -1258,9 +1405,9 @@ async function triggerSendButtons() {
   const sendBtn = document.getElementById('send-all-btn');
   const fillBtn = document.getElementById('fill-input-btn');
   const statusEl = document.getElementById('send-status');
+  const sendFocusRequestId = restoreUnifiedInputFocusAfterSend(getChatgptPanelsWithFrames());
 
   try {
-    restoreUnifiedInputFocusAfterSend();
     sendBtn.disabled = true;
     fillBtn.disabled = true;
     statusEl.textContent = 'Sending...';
@@ -1271,6 +1418,7 @@ async function triggerSendButtons() {
       if (panel.iframe && panel.iframe.contentWindow) {
         panel.iframe.contentWindow.postMessage({
           type: 'TRIGGER_SEND',
+          requestId: sendFocusRequestId,
           providerMode: getPanelProviderMode(panel),
           context: 'multi-panel'
         }, '*');
@@ -1760,6 +1908,7 @@ function setupEventListeners() {
   document.addEventListener('click', cancelSendFocusRestoreOnUserIntent, true);
   document.addEventListener('focusin', cancelSendFocusRestoreOnUserIntent, true);
   document.addEventListener('keydown', cancelSendFocusRestoreOnUserIntent, true);
+  window.addEventListener('message', handleProviderStatusMessage);
 
   // Layout modal outside click
   document.getElementById('layout-modal').addEventListener('click', (e) => {

--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -524,15 +524,21 @@ function handleProviderStatusMessage(event) {
   }
 
   const panel = panels.find(candidate => candidate.iframe?.contentWindow === event.source);
-  if (!panel || !isChatgptProvider(panel.providerId) || data.provider !== panel.providerId) {
+  if (!panel || data.provider !== panel.providerId) {
     return;
   }
 
   switch (data.type) {
     case PANELIZE_PROVIDER_BUSY:
+      if (!isChatgptProvider(panel.providerId)) {
+        return;
+      }
       handleSendFocusProviderBusy(panel, data.requestId);
       break;
     case PANELIZE_PROVIDER_IDLE:
+      if (!isChatgptProvider(panel.providerId)) {
+        return;
+      }
       handleSendFocusProviderIdle(panel, data.requestId);
       break;
     case PANELIZE_PROVIDER_USER_INTERACTION:

--- a/tests/chatgpt-content-script.test.js
+++ b/tests/chatgpt-content-script.test.js
@@ -1,0 +1,164 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const contentScriptSource = readFileSync(
+  resolve(process.cwd(), 'content-scripts/text-injection-all-providers.js'),
+  'utf8'
+);
+
+function dispatchMultiPanelMessage(payload) {
+  window.dispatchEvent(new MessageEvent('message', { data: payload }));
+}
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function createChatgptComposerDom({ includeSendButton = true, includeStopButton = false } = {}) {
+  document.body.innerHTML = `
+    <form data-type="unified-composer">
+      <div id="prompt-textarea" contenteditable="true" role="textbox" aria-label="Chat with ChatGPT"></div>
+      ${includeSendButton ? '<button type="button" data-testid="send-button" aria-label="Send prompt">Send</button>' : ''}
+      ${includeStopButton ? '<button type="button" data-testid="stop-button" aria-label="Stop streaming">Stop</button>' : ''}
+    </form>
+  `;
+
+  return {
+    composer: document.querySelector('form[data-type="unified-composer"]'),
+    prompt: document.getElementById('prompt-textarea'),
+    getSendButton: () => document.querySelector('button[data-testid="send-button"]'),
+    getStopButton: () => document.querySelector('button[data-testid="stop-button"]'),
+  };
+}
+
+function getProviderStatusCalls(postMessageSpy, type) {
+  return postMessageSpy.mock.calls
+    .map(call => call[0])
+    .filter(payload => payload?.type === type && payload?.context === 'multi-panel-provider-status');
+}
+
+describe('chatgpt content script provider status', () => {
+  beforeAll(() => {
+    window.eval(contentScriptSource);
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.happyDOM.setURL('https://chatgpt.com/c/test');
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      value: { postMessage: vi.fn() },
+    });
+    createChatgptComposerDom();
+  });
+
+  it('does not report busy before the stop button appears', async () => {
+    const postMessageSpy = window.parent.postMessage;
+
+    dispatchMultiPanelMessage({
+      type: 'TRIGGER_SEND',
+      requestId: 'req-pending',
+      context: 'multi-panel',
+    });
+
+    await wait(150);
+
+    expect(getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_BUSY')).toHaveLength(0);
+  });
+
+  it('reports busy when the ChatGPT stop button appears', async () => {
+    const postMessageSpy = window.parent.postMessage;
+    const { composer } = createChatgptComposerDom({ includeSendButton: true, includeStopButton: false });
+
+    dispatchMultiPanelMessage({
+      type: 'TRIGGER_SEND',
+      requestId: 'req-busy',
+      context: 'multi-panel',
+    });
+
+    await wait(100);
+    composer.insertAdjacentHTML('beforeend', '<button type="button" data-testid="stop-button" aria-label="Stop streaming">Stop</button>');
+    await wait(50);
+
+    const busyCalls = getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_BUSY');
+    expect(busyCalls).toHaveLength(1);
+    expect(busyCalls[0]).toMatchObject({
+      requestId: 'req-busy',
+      provider: 'chatgpt',
+      phase: 'busy',
+    });
+  });
+
+  it('reports idle after the stop button disappears for 800ms', async () => {
+    const postMessageSpy = window.parent.postMessage;
+    const { getStopButton } = createChatgptComposerDom({ includeSendButton: true, includeStopButton: false });
+
+    dispatchMultiPanelMessage({
+      type: 'TRIGGER_SEND',
+      requestId: 'req-idle',
+      context: 'multi-panel',
+    });
+
+    await wait(100);
+    document.querySelector('form[data-type="unified-composer"]').insertAdjacentHTML(
+      'beforeend',
+      '<button type="button" data-testid="stop-button" aria-label="Stop streaming">Stop</button>'
+    );
+    await wait(50);
+    getStopButton()?.remove();
+    await wait(850);
+
+    const idleCalls = getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_IDLE');
+    expect(idleCalls).toHaveLength(1);
+    expect(idleCalls[0]).toMatchObject({
+      requestId: 'req-idle',
+      provider: 'chatgpt',
+      phase: 'idle',
+    });
+  });
+
+  it('does not report idle when the stop button briefly reappears', async () => {
+    const postMessageSpy = window.parent.postMessage;
+    const { composer, getStopButton } = createChatgptComposerDom({ includeSendButton: true, includeStopButton: false });
+
+    dispatchMultiPanelMessage({
+      type: 'TRIGGER_SEND',
+      requestId: 'req-flicker',
+      context: 'multi-panel',
+    });
+
+    await wait(100);
+    composer.insertAdjacentHTML('beforeend', '<button type="button" data-testid="stop-button" aria-label="Stop streaming">Stop</button>');
+    await wait(50);
+    getStopButton()?.remove();
+    await wait(300);
+    composer.insertAdjacentHTML('beforeend', '<button type="button" data-testid="stop-button" aria-label="Stop streaming">Stop</button>');
+    await wait(650);
+
+    expect(getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_IDLE')).toHaveLength(0);
+
+    getStopButton()?.remove();
+    await wait(850);
+
+    expect(getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_IDLE')).toHaveLength(1);
+  });
+
+  it('stops tracking when busy is never observed within 2 seconds', async () => {
+    const postMessageSpy = window.parent.postMessage;
+    const { composer } = createChatgptComposerDom({ includeSendButton: true, includeStopButton: false });
+
+    dispatchMultiPanelMessage({
+      type: 'TRIGGER_SEND',
+      requestId: 'req-fallback',
+      context: 'multi-panel',
+    });
+
+    await wait(2200);
+    composer.insertAdjacentHTML('beforeend', '<button type="button" data-testid="stop-button" aria-label="Stop streaming">Stop</button>');
+    await wait(100);
+
+    expect(getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_BUSY')).toHaveLength(0);
+    expect(getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_IDLE')).toHaveLength(0);
+  });
+});

--- a/tests/chatgpt-content-script.test.js
+++ b/tests/chatgpt-content-script.test.js
@@ -161,4 +161,34 @@ describe('chatgpt content script provider status', () => {
     expect(getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_BUSY')).toHaveLength(0);
     expect(getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_IDLE')).toHaveLength(0);
   });
+
+  it('reports user interaction for non-chatgpt providers during send tracking', async () => {
+    window.happyDOM.setURL('https://gemini.google.com/app');
+    document.body.innerHTML = '<div class="ql-editor" contenteditable="true"></div>';
+
+    const postMessageSpy = window.parent.postMessage;
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+
+    dispatchMultiPanelMessage({
+      type: 'TRIGGER_SEND',
+      requestId: 'req-gemini-user-interaction',
+      context: 'multi-panel',
+    });
+
+    const pointerdownHandler = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === 'pointerdown'
+    )?.[1];
+
+    expect(pointerdownHandler).toBeTypeOf('function');
+
+    pointerdownHandler({ isTrusted: true });
+
+    const interactionCalls = getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_USER_INTERACTION');
+    expect(interactionCalls).toHaveLength(1);
+    expect(interactionCalls[0]).toMatchObject({
+      requestId: 'req-gemini-user-interaction',
+      provider: 'gemini',
+      phase: 'user-interaction',
+    });
+  });
 });

--- a/tests/e2e/focus-protection.e2e.test.js
+++ b/tests/e2e/focus-protection.e2e.test.js
@@ -205,4 +205,63 @@ test.describe('Focus Protection E2E', () => {
     const activeId = await page.evaluate(() => window.getActiveElementId());
     expect(activeId).not.toBe('unified-input');
   });
+
+  test('Test 9: Send all button should keep unified input focused', async () => {
+    await page.evaluate(() => window.addControlledIframe());
+    await page.evaluate(() => window.setSendFocusStealDelays([100, 1000, 4000, 9000]));
+
+    await page.fill('#unified-input', 'hello');
+    await page.click('#send-all-btn');
+    await page.waitForTimeout(10500);
+
+    const activeId = await page.evaluate(() => window.getActiveElementId());
+    expect(activeId).toBe('unified-input');
+  });
+
+  test('Test 10: Enter send should keep unified input focused', async () => {
+    await page.evaluate(() => window.addControlledIframe());
+    await page.evaluate(() => window.setSendFocusStealDelays([100, 1200, 4200]));
+
+    await page.focus('#unified-input');
+    await page.keyboard.type('hello');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(4800);
+
+    const activeId = await page.evaluate(() => window.getActiveElementId());
+    expect(activeId).toBe('unified-input');
+  });
+
+  test('Test 11: Trigger-send path should keep unified input focused', async () => {
+    await page.evaluate(() => window.addControlledIframe());
+    await page.evaluate(() => window.setSendFocusStealDelays([100, 1000, 2500]));
+
+    await page.focus('#unified-input');
+    await page.waitForTimeout(50);
+    await page.evaluate(() => window.triggerSendAllWithoutText());
+    await page.waitForTimeout(3200);
+
+    const activeId = await page.evaluate(() => window.getActiveElementId());
+    expect(activeId).toBe('unified-input');
+  });
+
+  test('Test 12: User interaction should cancel send focus restore', async () => {
+    await page.evaluate(() => window.addControlledIframe());
+    await page.waitForTimeout(3200);
+    await page.evaluate(() => window.setSendFocusStealDelays([100, 1000, 4000]));
+
+    await page.fill('#unified-input', 'hello');
+    await page.click('#send-all-btn');
+    await page.waitForTimeout(150);
+
+    await page.click('#other-control-input');
+    const debugState = await page.evaluate(() => window.getSendRestoreDebugState());
+    expect(debugState.userIntentCancelCount).toBeGreaterThan(0);
+    expect(debugState.pendingTimerCount).toBe(0);
+
+    await page.focus('#other-control-input');
+    await page.waitForTimeout(4200);
+
+    const activeId = await page.evaluate(() => window.getActiveElementId());
+    expect(activeId).not.toBe('unified-input');
+  });
 });

--- a/tests/e2e/focus-protection.e2e.test.js
+++ b/tests/e2e/focus-protection.e2e.test.js
@@ -272,12 +272,14 @@ test.describe('Focus Protection E2E', () => {
   });
 
   test('Test 13: Provider interaction message should cancel send focus restore', async () => {
-    await page.evaluate(() => window.addControlledIframe());
+    await page.evaluate(() => {
+      window.setControlledIframeProvider('gemini');
+      return window.addControlledIframe();
+    });
     await page.waitForTimeout(3200);
     await page.evaluate(() => {
       window.setSendFocusStealDelays([100, 1000, 4000]);
       window.setSendProviderStatusTimeline([
-        { delay: 100, type: 'PANELIZE_PROVIDER_BUSY' },
         { delay: 300, type: 'PANELIZE_PROVIDER_USER_INTERACTION' }
       ]);
     });

--- a/tests/e2e/focus-protection.e2e.test.js
+++ b/tests/e2e/focus-protection.e2e.test.js
@@ -208,11 +208,17 @@ test.describe('Focus Protection E2E', () => {
 
   test('Test 9: Send all button should keep unified input focused', async () => {
     await page.evaluate(() => window.addControlledIframe());
-    await page.evaluate(() => window.setSendFocusStealDelays([100, 1000, 4000, 9000]));
+    await page.evaluate(() => {
+      window.setSendFocusStealDelays([100, 1000, 4000, 9000, 12500]);
+      window.setSendProviderStatusTimeline([
+        { delay: 100, type: 'PANELIZE_PROVIDER_BUSY' },
+        { delay: 13000, type: 'PANELIZE_PROVIDER_IDLE' }
+      ]);
+    });
 
     await page.fill('#unified-input', 'hello');
     await page.click('#send-all-btn');
-    await page.waitForTimeout(10500);
+    await page.waitForTimeout(12800);
 
     const activeId = await page.evaluate(() => window.getActiveElementId());
     expect(activeId).toBe('unified-input');
@@ -263,5 +269,28 @@ test.describe('Focus Protection E2E', () => {
 
     const activeId = await page.evaluate(() => window.getActiveElementId());
     expect(activeId).not.toBe('unified-input');
+  });
+
+  test('Test 13: Provider interaction message should cancel send focus restore', async () => {
+    await page.evaluate(() => window.addControlledIframe());
+    await page.waitForTimeout(3200);
+    await page.evaluate(() => {
+      window.setSendFocusStealDelays([100, 1000, 4000]);
+      window.setSendProviderStatusTimeline([
+        { delay: 100, type: 'PANELIZE_PROVIDER_BUSY' },
+        { delay: 300, type: 'PANELIZE_PROVIDER_USER_INTERACTION' }
+      ]);
+    });
+
+    await page.fill('#unified-input', 'hello');
+    await page.click('#send-all-btn');
+    await page.waitForTimeout(4200);
+
+    const debugState = await page.evaluate(() => window.getSendRestoreDebugState());
+    expect(debugState.pendingTimerCount).toBe(0);
+    expect(debugState.activePanelCount).toBe(0);
+
+    const activeTag = await page.evaluate(() => window.getActiveElementTag());
+    expect(activeTag).toBe('IFRAME');
   });
 });

--- a/tests/e2e/test-focus-protection.html
+++ b/tests/e2e/test-focus-protection.html
@@ -39,6 +39,7 @@
     let sendFocusActivePanelIds = new Set();
     let sendFocusBusyDetectionTimeoutIds = new Map();
     let sendFocusHardTimeoutIds = new Map();
+    let controlledIframeProviderId = 'chatgpt';
     let newChatFocusStealDelays = [];
     let sendFocusStealDelays = [];
     let sendProviderStatusTimeline = [];
@@ -162,7 +163,7 @@
 
       return {
         id: 'chatgpt-panel',
-        providerId: 'chatgpt',
+        providerId: controlledIframeProviderId,
         iframe
       };
     }
@@ -458,6 +459,10 @@
       sendFocusStealDelays = Array.isArray(delays) ? delays.slice() : [];
     };
 
+    window.setControlledIframeProvider = function(providerId) {
+      controlledIframeProviderId = providerId || 'chatgpt';
+    };
+
     window.setSendProviderStatusTimeline = function(entries) {
       sendProviderStatusTimeline = Array.isArray(entries) ? entries.map((entry) => ({
         delay: Number(entry.delay) || 0,
@@ -487,6 +492,7 @@
       newChatFocusStealDelays = [];
       sendFocusStealDelays = [];
       sendProviderStatusTimeline = [];
+      controlledIframeProviderId = 'chatgpt';
       userIntentCancelCount = 0;
       lastUserIntentCancelTarget = null;
       cancelUnifiedInputFocusRestore();

--- a/tests/e2e/test-focus-protection.html
+++ b/tests/e2e/test-focus-protection.html
@@ -34,10 +34,23 @@
     let isRestoringFocusAfterNewChat = false;
     let sendFocusRestoreTimerIds = [];
     let isRestoringFocusAfterSend = false;
+    let activeSendFocusRequestId = null;
+    let sendFocusRequestCounter = 0;
+    let sendFocusActivePanelIds = new Set();
+    let sendFocusBusyDetectionTimeoutIds = new Map();
+    let sendFocusHardTimeoutIds = new Map();
     let newChatFocusStealDelays = [];
     let sendFocusStealDelays = [];
+    let sendProviderStatusTimeline = [];
     let userIntentCancelCount = 0;
     let lastUserIntentCancelTarget = null;
+    const SEND_FOCUS_RESTORE_DELAYS = [0, 80, 200, 400, 800, 1500, 2500, 4000, 6000, 8000, 10000, 12000];
+    const SEND_FOCUS_NO_BUSY_TIMEOUT_MS = 2000;
+    const SEND_FOCUS_HARD_TIMEOUT_MS = 90000;
+    const MULTI_PANEL_PROVIDER_STATUS_CONTEXT = 'multi-panel-provider-status';
+    const PANELIZE_PROVIDER_BUSY = 'PANELIZE_PROVIDER_BUSY';
+    const PANELIZE_PROVIDER_IDLE = 'PANELIZE_PROVIDER_IDLE';
+    const PANELIZE_PROVIDER_USER_INTERACTION = 'PANELIZE_PROVIDER_USER_INTERACTION';
 
     function focusUnifiedInput(options = {}) {
       const force = Boolean(options.force);
@@ -69,6 +82,12 @@
     function cancelUnifiedInputFocusRestoreAfterSend() {
       sendFocusRestoreTimerIds.forEach(timerId => clearTimeout(timerId));
       sendFocusRestoreTimerIds = [];
+      sendFocusBusyDetectionTimeoutIds.forEach(timerId => clearTimeout(timerId));
+      sendFocusBusyDetectionTimeoutIds.clear();
+      sendFocusHardTimeoutIds.forEach(timerId => clearTimeout(timerId));
+      sendFocusHardTimeoutIds.clear();
+      sendFocusActivePanelIds.clear();
+      activeSendFocusRequestId = null;
       isRestoringFocusAfterSend = false;
     }
 
@@ -110,26 +129,122 @@
       });
     }
 
-    function restoreUnifiedInputFocusAfterSend() {
+    function createSendFocusRequestId() {
+      sendFocusRequestCounter += 1;
+      return `send-focus-${Date.now()}-${sendFocusRequestCounter}`;
+    }
+
+    function clearSendFocusProviderTimeout(timeoutMap, panelId) {
+      const timerId = timeoutMap.get(panelId);
+      if (typeof timerId === 'number') {
+        clearTimeout(timerId);
+      }
+      timeoutMap.delete(panelId);
+    }
+
+    function maybeStopSendFocusRestore() {
+      if (sendFocusRestoreTimerIds.length > 0) {
+        return;
+      }
+
+      if (sendFocusActivePanelIds.size > 0) {
+        return;
+      }
+
+      cancelUnifiedInputFocusRestoreAfterSend();
+    }
+
+    function getControlledIframePanel() {
+      const iframe = document.querySelector('#iframe-container iframe');
+      if (!iframe || !iframe.contentWindow) {
+        return null;
+      }
+
+      return {
+        id: 'chatgpt-panel',
+        providerId: 'chatgpt',
+        iframe
+      };
+    }
+
+    function scheduleSendFocusBusyDetectionTimeout(panel, requestId) {
+      clearSendFocusProviderTimeout(sendFocusBusyDetectionTimeoutIds, panel.id);
+
+      const timerId = setTimeout(() => {
+        if (activeSendFocusRequestId !== requestId) {
+          return;
+        }
+
+        sendFocusBusyDetectionTimeoutIds.delete(panel.id);
+      }, SEND_FOCUS_NO_BUSY_TIMEOUT_MS);
+
+      sendFocusBusyDetectionTimeoutIds.set(panel.id, timerId);
+    }
+
+    function scheduleSendFocusHardTimeout(panelId, requestId) {
+      clearSendFocusProviderTimeout(sendFocusHardTimeoutIds, panelId);
+
+      const timerId = setTimeout(() => {
+        if (activeSendFocusRequestId !== requestId) {
+          return;
+        }
+
+        sendFocusActivePanelIds.delete(panelId);
+        sendFocusHardTimeoutIds.delete(panelId);
+        maybeStopSendFocusRestore();
+      }, SEND_FOCUS_HARD_TIMEOUT_MS);
+
+      sendFocusHardTimeoutIds.set(panelId, timerId);
+    }
+
+    function handleSendFocusProviderBusy(panelId, requestId) {
+      if (activeSendFocusRequestId !== requestId) {
+        return;
+      }
+
+      clearSendFocusProviderTimeout(sendFocusBusyDetectionTimeoutIds, panelId);
+      sendFocusActivePanelIds.add(panelId);
+      isRestoringFocusAfterSend = true;
+      scheduleSendFocusHardTimeout(panelId, requestId);
+      focusUnifiedInput({ force: true });
+    }
+
+    function handleSendFocusProviderIdle(panelId, requestId) {
+      if (activeSendFocusRequestId !== requestId) {
+        return;
+      }
+
+      clearSendFocusProviderTimeout(sendFocusBusyDetectionTimeoutIds, panelId);
+      clearSendFocusProviderTimeout(sendFocusHardTimeoutIds, panelId);
+      sendFocusActivePanelIds.delete(panelId);
+      maybeStopSendFocusRestore();
+    }
+
+    function restoreUnifiedInputFocusAfterSend(trackedPanels = []) {
       cancelUnifiedInputFocusRestoreAfterSend();
       isRestoringFocusAfterSend = true;
+      activeSendFocusRequestId = createSendFocusRequestId();
+      trackedPanels.forEach((panel) => scheduleSendFocusBusyDetectionTimeout(panel, activeSendFocusRequestId));
 
-      const restoreDelays = [0, 80, 200, 400, 800, 1500, 2500, 4000, 6000, 8000, 10000, 12000];
-      restoreDelays.forEach((delay, index) => {
+      const requestId = activeSendFocusRequestId;
+      SEND_FOCUS_RESTORE_DELAYS.forEach((delay, index) => {
         const timerId = setTimeout(() => {
-          if (!isRestoringFocusAfterSend) {
+          if (!isRestoringFocusAfterSend || activeSendFocusRequestId !== requestId) {
             return;
           }
 
           focusUnifiedInput({ force: true });
 
-          if (index === restoreDelays.length - 1) {
-            cancelUnifiedInputFocusRestoreAfterSend();
+          if (index === SEND_FOCUS_RESTORE_DELAYS.length - 1) {
+            sendFocusRestoreTimerIds = [];
+            maybeStopSendFocusRestore();
           }
         }, delay);
 
         sendFocusRestoreTimerIds.push(timerId);
       });
+
+      return requestId;
     }
 
     function scheduleControlledIframeFocusSteal(delays) {
@@ -152,9 +267,35 @@
       return true;
     }
 
+    function scheduleControlledIframeProviderStatusTimeline(requestId) {
+      const panel = getControlledIframePanel();
+      if (!panel || !panel.iframe.contentWindow) {
+        return;
+      }
+
+      sendProviderStatusTimeline.forEach((entry) => {
+        const delay = Number(entry.delay) || 0;
+        const type = entry.type;
+        setTimeout(() => {
+          if (activeSendFocusRequestId !== requestId || !panel.iframe.contentWindow.reportPanelizeStatus) {
+            return;
+          }
+
+          panel.iframe.contentWindow.reportPanelizeStatus({
+            type,
+            requestId,
+            provider: panel.providerId,
+            context: MULTI_PANEL_PROVIDER_STATUS_CONTEXT
+          });
+        }, delay);
+      });
+    }
+
     function sendAll() {
-      restoreUnifiedInputFocusAfterSend();
+      const panel = getControlledIframePanel();
+      const requestId = restoreUnifiedInputFocusAfterSend(panel ? [panel] : []);
       scheduleControlledIframeFocusSteal(sendFocusStealDelays);
+      scheduleControlledIframeProviderStatusTimeline(requestId);
     }
 
     // === Focus protection logic (identical to multi-panel.js) ===
@@ -207,6 +348,26 @@
     document.addEventListener('click', cancelSendFocusRestoreOnUserIntent, true);
     document.addEventListener('focusin', cancelSendFocusRestoreOnUserIntent, true);
     document.addEventListener('keydown', cancelSendFocusRestoreOnUserIntent, true);
+
+    window.addEventListener('message', (event) => {
+      const data = event.data;
+      if (!data || data.context !== MULTI_PANEL_PROVIDER_STATUS_CONTEXT || !data.requestId) {
+        return;
+      }
+
+      const panel = getControlledIframePanel();
+      if (!panel || event.source !== panel.iframe.contentWindow) {
+        return;
+      }
+
+      if (data.type === PANELIZE_PROVIDER_BUSY) {
+        handleSendFocusProviderBusy(panel.id, data.requestId);
+      } else if (data.type === PANELIZE_PROVIDER_IDLE) {
+        handleSendFocusProviderIdle(panel.id, data.requestId);
+      } else if (data.type === PANELIZE_PROVIDER_USER_INTERACTION && data.requestId === activeSendFocusRequestId) {
+        cancelUnifiedInputFocusRestoreAfterSend();
+      }
+    });
 
     const preserveNewChatButtonFocus = (event) => {
       event.preventDefault();
@@ -270,7 +431,11 @@
       return new Promise((resolve) => {
         loadingIframeCount++;
         const iframe = document.createElement('iframe');
-        iframe.srcdoc = `<html><body><input id="ai-input" type="text"></body></html>`;
+        iframe.srcdoc = `<html><body><input id="ai-input" type="text"><script>
+          window.reportPanelizeStatus = function(payload) {
+            window.parent.postMessage(payload, '*');
+          };
+        <\/script></body></html>`;
         iframe.addEventListener('load', () => {
           setTimeout(() => {
             loadingIframeCount = Math.max(0, loadingIframeCount - 1);
@@ -291,6 +456,13 @@
 
     window.setSendFocusStealDelays = function(delays) {
       sendFocusStealDelays = Array.isArray(delays) ? delays.slice() : [];
+    };
+
+    window.setSendProviderStatusTimeline = function(entries) {
+      sendProviderStatusTimeline = Array.isArray(entries) ? entries.map((entry) => ({
+        delay: Number(entry.delay) || 0,
+        type: entry.type
+      })) : [];
     };
 
     window.triggerSendAllWithoutText = function() {
@@ -314,6 +486,7 @@
       loadingIframeCount = 0;
       newChatFocusStealDelays = [];
       sendFocusStealDelays = [];
+      sendProviderStatusTimeline = [];
       userIntentCancelCount = 0;
       lastUserIntentCancelTarget = null;
       cancelUnifiedInputFocusRestore();
@@ -333,6 +506,8 @@
       return {
         isRestoringFocusAfterSend,
         pendingTimerCount: sendFocusRestoreTimerIds.length,
+        activePanelCount: sendFocusActivePanelIds.size,
+        activeSendFocusRequestId,
         userIntentCancelCount,
         lastUserIntentCancelTarget
       };

--- a/tests/e2e/test-focus-protection.html
+++ b/tests/e2e/test-focus-protection.html
@@ -16,6 +16,7 @@
   <textarea id="unified-input" rows="2" placeholder="Type here..."></textarea>
   <br>
   <button id="new-chat-btn" type="button">New Chat for All</button>
+  <button id="send-all-btn" type="button">Send All</button>
   <input id="other-control-input" type="text" placeholder="Other control">
 
   <div id="iframe-container">
@@ -25,12 +26,16 @@
   <script>
     const inputTextarea = document.getElementById('unified-input');
     const newChatBtn = document.getElementById('new-chat-btn');
+    const sendAllBtn = document.getElementById('send-all-btn');
 
     // === Loading counter (same as multi-panel.js) ===
     let loadingIframeCount = 0;
     let newChatFocusRestoreTimerIds = [];
     let isRestoringFocusAfterNewChat = false;
+    let sendFocusRestoreTimerIds = [];
+    let isRestoringFocusAfterSend = false;
     let newChatFocusStealDelays = [];
+    let sendFocusStealDelays = [];
     let userIntentCancelCount = 0;
     let lastUserIntentCancelTarget = null;
 
@@ -51,10 +56,20 @@
       });
     }
 
+    function shouldPreserveUnifiedInputFocus() {
+      return loadingIframeCount > 0 || isRestoringFocusAfterNewChat || isRestoringFocusAfterSend;
+    }
+
     function cancelUnifiedInputFocusRestore() {
       newChatFocusRestoreTimerIds.forEach(timerId => clearTimeout(timerId));
       newChatFocusRestoreTimerIds = [];
       isRestoringFocusAfterNewChat = false;
+    }
+
+    function cancelUnifiedInputFocusRestoreAfterSend() {
+      sendFocusRestoreTimerIds.forEach(timerId => clearTimeout(timerId));
+      sendFocusRestoreTimerIds = [];
+      isRestoringFocusAfterSend = false;
     }
 
     function isUnifiedInputOrNewChatControl(target) {
@@ -63,6 +78,14 @@
       }
 
       return Boolean(target.closest('#unified-input, #new-chat-btn'));
+    }
+
+    function isUnifiedInputOrSendControl(target) {
+      if (!(target instanceof Element)) {
+        return false;
+      }
+
+      return Boolean(target.closest('#unified-input, #send-all-btn'));
     }
 
     function restoreUnifiedInputFocusAfterNewChat() {
@@ -87,6 +110,28 @@
       });
     }
 
+    function restoreUnifiedInputFocusAfterSend() {
+      cancelUnifiedInputFocusRestoreAfterSend();
+      isRestoringFocusAfterSend = true;
+
+      const restoreDelays = [0, 80, 200, 400, 800, 1500, 2500, 4000, 6000, 8000, 10000, 12000];
+      restoreDelays.forEach((delay, index) => {
+        const timerId = setTimeout(() => {
+          if (!isRestoringFocusAfterSend) {
+            return;
+          }
+
+          focusUnifiedInput({ force: true });
+
+          if (index === restoreDelays.length - 1) {
+            cancelUnifiedInputFocusRestoreAfterSend();
+          }
+        }, delay);
+
+        sendFocusRestoreTimerIds.push(timerId);
+      });
+    }
+
     function scheduleControlledIframeFocusSteal(delays) {
       const iframe = document.querySelector('#iframe-container iframe');
       if (!iframe || !iframe.contentDocument) {
@@ -107,9 +152,14 @@
       return true;
     }
 
+    function sendAll() {
+      restoreUnifiedInputFocusAfterSend();
+      scheduleControlledIframeFocusSteal(sendFocusStealDelays);
+    }
+
     // === Focus protection logic (identical to multi-panel.js) ===
     inputTextarea.addEventListener('blur', () => {
-      if (loadingIframeCount > 0) {
+      if (shouldPreserveUnifiedInputFocus()) {
         focusUnifiedInput();
       }
     });
@@ -136,7 +186,33 @@
     document.addEventListener('focusin', cancelNewChatFocusRestoreOnUserIntent, true);
     document.addEventListener('keydown', cancelNewChatFocusRestoreOnUserIntent, true);
 
+    const cancelSendFocusRestoreOnUserIntent = (event) => {
+      if (!isRestoringFocusAfterSend) {
+        return;
+      }
+
+      if (isUnifiedInputOrSendControl(event.target)) {
+        return;
+      }
+
+      userIntentCancelCount += 1;
+      lastUserIntentCancelTarget = event.target instanceof Element
+        ? (event.target.id || event.target.tagName)
+        : String(event.target);
+      cancelUnifiedInputFocusRestoreAfterSend();
+    };
+
+    document.addEventListener('pointerdown', cancelSendFocusRestoreOnUserIntent, true);
+    document.addEventListener('mousedown', cancelSendFocusRestoreOnUserIntent, true);
+    document.addEventListener('click', cancelSendFocusRestoreOnUserIntent, true);
+    document.addEventListener('focusin', cancelSendFocusRestoreOnUserIntent, true);
+    document.addEventListener('keydown', cancelSendFocusRestoreOnUserIntent, true);
+
     const preserveNewChatButtonFocus = (event) => {
+      event.preventDefault();
+    };
+
+    const preserveSendAllButtonFocus = (event) => {
       event.preventDefault();
     };
 
@@ -145,6 +221,21 @@
     newChatBtn.addEventListener('click', () => {
       restoreUnifiedInputFocusAfterNewChat();
       scheduleControlledIframeFocusSteal(newChatFocusStealDelays);
+    });
+
+    sendAllBtn.addEventListener('pointerdown', preserveSendAllButtonFocus);
+    sendAllBtn.addEventListener('mousedown', preserveSendAllButtonFocus);
+    sendAllBtn.addEventListener('click', () => {
+      sendAll();
+    });
+
+    inputTextarea.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' || event.shiftKey) {
+        return;
+      }
+
+      event.preventDefault();
+      sendAll();
     });
 
     focusUnifiedInput({ force: true });
@@ -198,6 +289,14 @@
       newChatFocusStealDelays = Array.isArray(delays) ? delays.slice() : [];
     };
 
+    window.setSendFocusStealDelays = function(delays) {
+      sendFocusStealDelays = Array.isArray(delays) ? delays.slice() : [];
+    };
+
+    window.triggerSendAllWithoutText = function() {
+      sendAll();
+    };
+
     window.getActiveElementTag = function() {
       return document.activeElement ? document.activeElement.tagName : 'null';
     };
@@ -214,15 +313,26 @@
       document.getElementById('iframe-container').innerHTML = '';
       loadingIframeCount = 0;
       newChatFocusStealDelays = [];
+      sendFocusStealDelays = [];
       userIntentCancelCount = 0;
       lastUserIntentCancelTarget = null;
       cancelUnifiedInputFocusRestore();
+      cancelUnifiedInputFocusRestoreAfterSend();
     };
 
     window.getNewChatRestoreDebugState = function() {
       return {
         isRestoringFocusAfterNewChat,
         pendingTimerCount: newChatFocusRestoreTimerIds.length,
+        userIntentCancelCount,
+        lastUserIntentCancelTarget
+      };
+    };
+
+    window.getSendRestoreDebugState = function() {
+      return {
+        isRestoringFocusAfterSend,
+        pendingTimerCount: sendFocusRestoreTimerIds.length,
         userIntentCancelCount,
         lastUserIntentCancelTarget
       };


### PR DESCRIPTION
## Summary
- preserve unified input focus when send all is triggered
- drive ChatGPT send-focus protection from busy and idle state
- stop send focus restoration when the user interacts with any provider input

## Testing
- node --check /Users/manho/src/Panelize/multi-panel/multi-panel.js
- node --check /Users/manho/src/Panelize/content-scripts/text-injection-all-providers.js
- npx vitest run tests/chatgpt-content-script.test.js tests/google-content-script.test.js
- npx playwright test tests/e2e/focus-protection.e2e.test.js