### PR TITLE
feat: add temporary chat toggle in multi panel

### DIFF
--- a/content-scripts/text-injection-all-providers.js
+++ b/content-scripts/text-injection-all-providers.js
@@ -10,10 +10,13 @@
   const PANELIZE_PROVIDER_BUSY = 'PANELIZE_PROVIDER_BUSY';
   const PANELIZE_PROVIDER_IDLE = 'PANELIZE_PROVIDER_IDLE';
   const PANELIZE_PROVIDER_USER_INTERACTION = 'PANELIZE_PROVIDER_USER_INTERACTION';
+  const PANELIZE_TEMP_CHAT_ENABLED = 'PANELIZE_TEMP_CHAT_ENABLED';
   const CHATGPT_STOP_BUTTON_SELECTOR = 'button[data-testid="stop-button"]';
   const CHATGPT_SEND_TRACKING_IDLE_DELAY_MS = 800;
   const CHATGPT_SEND_TRACKING_NO_BUSY_TIMEOUT_MS = 2000;
   const MULTI_PANEL_USER_INTERACTION_TRACKING_TIMEOUT_MS = 90000;
+  const TEMP_CHAT_POLL_INTERVAL_MS = 200;
+  const TEMP_CHAT_POLL_TIMEOUT_MS = 1200;
   let googleSearchReplaceOnNextFill = true;
   let chatgptSendTracking = null;
   let multiPanelUserInteractionTracking = null;
@@ -214,6 +217,16 @@
     google: 'https://www.google.com/search?udm=50'
   };
 
+  const TEMP_CHAT_BUTTON_SELECTORS = {
+    chatgpt: ['button[aria-label="Turn on temporary chat"]'],
+    claude: ['button[aria-label="Use incognito"]'],
+    gemini: [
+      'button[data-test-id="temp-chat-button"]',
+      'button[aria-label="Temporary chat"]'
+    ],
+    grok: ['a[href="/c#private"][aria-label="Switch to Private Chat"]']
+  };
+
   // Detect which provider we're on based on hostname
   function detectProvider() {
     const hostname = window.location.hostname;
@@ -338,6 +351,18 @@
       requestId,
       provider,
       phase,
+      context: MULTI_PANEL_PROVIDER_STATUS_CONTEXT
+    }, '*');
+  }
+
+  function postTemporaryChatEnabled(provider = detectProvider()) {
+    if (!provider || window.parent === window) {
+      return;
+    }
+
+    window.parent.postMessage({
+      type: PANELIZE_TEMP_CHAT_ENABLED,
+      provider,
       context: MULTI_PANEL_PROVIDER_STATUS_CONTEXT
     }, '*');
   }
@@ -590,6 +615,14 @@
     }
 
     return true;
+  }
+
+  function isElementEnabled(element) {
+    return Boolean(
+      element &&
+      !element.disabled &&
+      element.getAttribute('aria-disabled') !== 'true'
+    );
   }
 
   function fillGoogleSearchInput(text) {
@@ -890,6 +923,29 @@
       ? 'https://www.google.com/'
       : 'https://www.google.com/search?udm=50';
     return true;
+  }
+
+  async function enableTemporaryChat(provider) {
+    const selectors = TEMP_CHAT_BUTTON_SELECTORS[provider];
+    if (!selectors || selectors.length === 0) {
+      console.log('[Temporary Chat] Provider does not support temporary chat:', provider);
+      return false;
+    }
+
+    const deadline = Date.now() + TEMP_CHAT_POLL_TIMEOUT_MS;
+    while (Date.now() <= deadline) {
+      const button = findDeepFirstVisibleElement(selectors) || findFirstVisibleElement(selectors);
+      if (button && isElementEnabled(button)) {
+        button.click();
+        postTemporaryChatEnabled(provider);
+        return true;
+      }
+
+      await sleep(TEMP_CHAT_POLL_INTERVAL_MS);
+    }
+
+    console.log('[Temporary Chat] Temporary chat control not found for provider:', provider);
+    return false;
   }
 
   // Find and click new chat button
@@ -1622,6 +1678,14 @@
         clickNewChatButton(provider, providerMode);
       } else {
         console.warn('[Text Injection] Provider not detected for NEW_CHAT');
+      }
+      return;
+    }
+
+    if (event.data.type === 'ENABLE_TEMP_CHAT' && event.data.context === 'multi-panel') {
+      const provider = detectProvider();
+      if (provider) {
+        void enableTemporaryChat(provider);
       }
       return;
     }

--- a/multi-panel/multi-panel.css
+++ b/multi-panel/multi-panel.css
@@ -135,11 +135,7 @@ body {
 .toolbar-icon-svg {
   width: 20px;
   height: 20px;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.7;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+  fill: currentColor;
 }
 
 .toolbar-btn:hover {

--- a/multi-panel/multi-panel.css
+++ b/multi-panel/multi-panel.css
@@ -132,6 +132,16 @@ body {
   transition: background 0.2s, color 0.2s;
 }
 
+.toolbar-icon-svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .toolbar-btn:hover {
   background: #f0f0f0;
   color: #333;

--- a/multi-panel/multi-panel.html
+++ b/multi-panel/multi-panel.html
@@ -55,7 +55,13 @@
           <span class="material-symbols-outlined">add_comment</span>
         </button>
         <button id="temporary-chat-btn" class="toolbar-btn" title="Temporary Chat for All" aria-label="Temporary Chat for All">
-          <span class="material-symbols-outlined">incognito</span>
+          <svg class="toolbar-icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M6.5 9.5h11l1.75 3.5H4.75z" />
+            <path d="M8.25 9.5c.35-2.35 1.9-4 3.75-4s3.4 1.65 3.75 4" />
+            <path d="M6.5 13h3.25a2 2 0 0 1 4.5 0h3.25" />
+            <path d="M8.25 16.25a2.25 2.25 0 1 1 0-4.5a2.25 2.25 0 0 1 0 4.5Z" />
+            <path d="M15.75 16.25a2.25 2.25 0 1 1 0-4.5a2.25 2.25 0 0 1 0 4.5Z" />
+          </svg>
         </button>
         <button id="layout-btn" class="toolbar-btn" title="Change Layout">
           <span class="material-symbols-outlined">grid_view</span>

--- a/multi-panel/multi-panel.html
+++ b/multi-panel/multi-panel.html
@@ -54,13 +54,9 @@
         <button id="new-chat-btn" class="toolbar-btn" title="New Chat for All">
           <span class="material-symbols-outlined">add_comment</span>
         </button>
-        <button id="temporary-chat-btn" class="toolbar-btn" title="Temporary Chat for All" aria-label="Temporary Chat for All">
+        <button id="temporary-chat-btn" class="toolbar-btn" title="Temporary Chat for All" aria-label="Temporary Chat for All" aria-pressed="false">
           <svg class="toolbar-icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M6.5 9.5h11l1.75 3.5H4.75z" />
-            <path d="M8.25 9.5c.35-2.35 1.9-4 3.75-4s3.4 1.65 3.75 4" />
-            <path d="M6.5 13h3.25a2 2 0 0 1 4.5 0h3.25" />
-            <path d="M8.25 16.25a2.25 2.25 0 1 1 0-4.5a2.25 2.25 0 0 1 0 4.5Z" />
-            <path d="M15.75 16.25a2.25 2.25 0 1 1 0-4.5a2.25 2.25 0 0 1 0 4.5Z" />
+            <path d="M17.06 13c-1.86 0-3.42 1.33-3.82 3.1c-.95-.41-1.82-.3-2.48-.01C10.35 14.31 8.79 13 6.94 13C4.77 13 3 14.79 3 17s1.77 4 3.94 4c2.06 0 3.74-1.62 3.9-3.68c.34-.24 1.23-.69 2.32.02c.18 2.05 1.84 3.66 3.9 3.66c2.17 0 3.94-1.79 3.94-4s-1.77-4-3.94-4M6.94 19.86c-1.56 0-2.81-1.28-2.81-2.86s1.26-2.86 2.81-2.86c1.56 0 2.81 1.28 2.81 2.86s-1.25 2.86-2.81 2.86m10.12 0c-1.56 0-2.81-1.28-2.81-2.86s1.25-2.86 2.81-2.86s2.82 1.28 2.82 2.86s-1.27 2.86-2.82 2.86M22 10.5H2V12h20zm-6.47-7.87c-.22-.49-.78-.75-1.31-.58L12 2.79l-2.23-.74l-.05-.01c-.53-.15-1.09.13-1.29.64L6 9h12l-2.44-6.32z" />
           </svg>
         </button>
         <button id="layout-btn" class="toolbar-btn" title="Change Layout">

--- a/multi-panel/multi-panel.html
+++ b/multi-panel/multi-panel.html
@@ -54,6 +54,9 @@
         <button id="new-chat-btn" class="toolbar-btn" title="New Chat for All">
           <span class="material-symbols-outlined">add_comment</span>
         </button>
+        <button id="temporary-chat-btn" class="toolbar-btn" title="Temporary Chat for All" aria-label="Temporary Chat for All">
+          <span class="material-symbols-outlined">incognito</span>
+        </button>
         <button id="layout-btn" class="toolbar-btn" title="Change Layout">
           <span class="material-symbols-outlined">grid_view</span>
         </button>

--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -43,6 +43,9 @@ let sendFocusRequestCounter = 0;
 let sendFocusActivePanelIds = new Set();
 let sendFocusBusyDetectionTimeoutIds = new Map();
 let sendFocusHardTimeoutIds = new Map();
+let tempChatRetryTimerIds = new Map();
+let tempChatCleanupTimerId = null;
+let tempChatPendingPanelIds = new Set();
 let currentGoogleProviderMode = DEFAULT_GOOGLE_PROVIDER_MODE;
 
 // 提示词编辑器状态
@@ -63,6 +66,10 @@ const MULTI_PANEL_PROVIDER_STATUS_CONTEXT = 'multi-panel-provider-status';
 const PANELIZE_PROVIDER_BUSY = 'PANELIZE_PROVIDER_BUSY';
 const PANELIZE_PROVIDER_IDLE = 'PANELIZE_PROVIDER_IDLE';
 const PANELIZE_PROVIDER_USER_INTERACTION = 'PANELIZE_PROVIDER_USER_INTERACTION';
+const PANELIZE_TEMP_CHAT_ENABLED = 'PANELIZE_TEMP_CHAT_ENABLED';
+const TEMP_CHAT_RETRY_DELAYS = [1200, 2500, 4000];
+const TEMP_CHAT_OPERATION_TIMEOUT_MS = 5000;
+const TEMP_CHAT_SUPPORTED_PROVIDERS = new Set(['chatgpt', 'gemini', 'claude', 'grok']);
 const LAYOUT_PANEL_COUNTS = {
   '1x1': 1,
   '1x2': 2,
@@ -147,6 +154,10 @@ function isGoogleProvider(providerId) {
 
 function isChatgptProvider(providerId) {
   return providerId === 'chatgpt';
+}
+
+function isTemporaryChatSupportedProvider(providerId) {
+  return TEMP_CHAT_SUPPORTED_PROVIDERS.has(providerId);
 }
 
 function getPanelProviderMode(panel) {
@@ -360,12 +371,42 @@ function cancelUnifiedInputFocusRestoreAfterSend() {
   isRestoringFocusAfterSend = false;
 }
 
+function setTemporaryChatButtonDisabled(disabled) {
+  const temporaryChatBtn = document.getElementById('temporary-chat-btn');
+  if (temporaryChatBtn) {
+    temporaryChatBtn.disabled = disabled;
+  }
+}
+
+function clearTemporaryChatRetriesForPanel(panelId) {
+  const timerIds = tempChatRetryTimerIds.get(panelId) || [];
+  timerIds.forEach(timerId => clearTimeout(timerId));
+  tempChatRetryTimerIds.delete(panelId);
+}
+
+function cancelTemporaryChatActivation({ restoreButton = true } = {}) {
+  tempChatRetryTimerIds.forEach((timerIds) => {
+    timerIds.forEach(timerId => clearTimeout(timerId));
+  });
+  tempChatRetryTimerIds.clear();
+  tempChatPendingPanelIds.clear();
+
+  if (typeof tempChatCleanupTimerId === 'number') {
+    clearTimeout(tempChatCleanupTimerId);
+  }
+  tempChatCleanupTimerId = null;
+
+  if (restoreButton) {
+    setTemporaryChatButtonDisabled(false);
+  }
+}
+
 function isUnifiedInputOrNewChatControl(target) {
   if (!(target instanceof Element)) {
     return false;
   }
 
-  return Boolean(target.closest('#unified-input, #new-chat-btn'));
+  return Boolean(target.closest('#unified-input, #new-chat-btn, #temporary-chat-btn'));
 }
 
 function isUnifiedInputOrSendControl(target) {
@@ -519,7 +560,8 @@ function handleProviderStatusMessage(event) {
     return;
   }
 
-  if (data.context !== MULTI_PANEL_PROVIDER_STATUS_CONTEXT || !data.requestId) {
+  const isTempChatMessage = data.type === PANELIZE_TEMP_CHAT_ENABLED;
+  if (data.context !== MULTI_PANEL_PROVIDER_STATUS_CONTEXT || (!data.requestId && !isTempChatMessage)) {
     return;
   }
 
@@ -545,6 +587,13 @@ function handleProviderStatusMessage(event) {
       if (data.requestId === activeSendFocusRequestId) {
         cancelUnifiedInputFocusRestoreAfterSend();
       }
+      break;
+    case PANELIZE_TEMP_CHAT_ENABLED:
+      if (!tempChatPendingPanelIds.has(panel.id)) {
+        return;
+      }
+      clearTemporaryChatRetriesForPanel(panel.id);
+      tempChatPendingPanelIds.delete(panel.id);
       break;
     default:
       break;
@@ -1268,6 +1317,18 @@ async function sendToPanel(panel, text, images = [], autoSubmit = true, requestI
   });
 }
 
+function postNewChatToAllPanels() {
+  panels.forEach(panel => {
+    if (panel.iframe && panel.iframe.contentWindow) {
+      panel.iframe.contentWindow.postMessage({
+        type: 'NEW_CHAT',
+        providerMode: getPanelProviderMode(panel),
+        context: 'multi-panel'
+      }, '*');
+    }
+  });
+}
+
 // Clear all input boxes (unified input + all panels)
 async function clearAllInputs() {
   // Clear unified input
@@ -1386,16 +1447,7 @@ async function newChatAllProviders() {
   // Disable button during operation
   newChatBtn.disabled = true;
 
-  // Send NEW_CHAT message to all panels
-  panels.forEach(panel => {
-    if (panel.iframe && panel.iframe.contentWindow) {
-      panel.iframe.contentWindow.postMessage({
-        type: 'NEW_CHAT',
-        providerMode: getPanelProviderMode(panel),
-        context: 'multi-panel'
-      }, '*');
-    }
-  });
+  postNewChatToAllPanels();
 
   restoreUnifiedInputFocusAfterNewChat();
   showToast('New chat created for all AIs');
@@ -1404,6 +1456,46 @@ async function newChatAllProviders() {
   setTimeout(() => {
     newChatBtn.disabled = false;
   }, 1000);
+}
+
+function scheduleTemporaryChatRetry(panel, delay) {
+  const timerId = setTimeout(() => {
+    if (!tempChatPendingPanelIds.has(panel.id) || !panel.iframe || !panel.iframe.contentWindow) {
+      return;
+    }
+
+    focusUnifiedInput({ force: true });
+    panel.iframe.contentWindow.postMessage({
+      type: 'ENABLE_TEMP_CHAT',
+      providerMode: getPanelProviderMode(panel),
+      context: 'multi-panel'
+    }, '*');
+  }, delay);
+
+  const timerIds = tempChatRetryTimerIds.get(panel.id) || [];
+  timerIds.push(timerId);
+  tempChatRetryTimerIds.set(panel.id, timerIds);
+}
+
+async function temporaryChatAllProviders() {
+  cancelTemporaryChatActivation({ restoreButton: false });
+  setTemporaryChatButtonDisabled(true);
+
+  postNewChatToAllPanels();
+  restoreUnifiedInputFocusAfterNewChat();
+
+  panels
+    .filter(panel => isTemporaryChatSupportedProvider(panel.providerId))
+    .forEach(panel => {
+      tempChatPendingPanelIds.add(panel.id);
+      TEMP_CHAT_RETRY_DELAYS.forEach(delay => scheduleTemporaryChatRetry(panel, delay));
+    });
+
+  tempChatCleanupTimerId = setTimeout(() => {
+    cancelTemporaryChatActivation();
+  }, TEMP_CHAT_OPERATION_TIMEOUT_MS);
+
+  showToast('Temporary chat enabled where supported');
 }
 
 // Trigger send buttons only (no text injection) - used after Fill
@@ -1700,6 +1792,15 @@ function setupEventListeners() {
   newChatBtn.addEventListener('pointerdown', preserveNewChatButtonFocus);
   newChatBtn.addEventListener('mousedown', preserveNewChatButtonFocus);
   newChatBtn.addEventListener('click', newChatAllProviders);
+
+  // Temporary Chat button
+  const temporaryChatBtn = document.getElementById('temporary-chat-btn');
+  const preserveTemporaryChatButtonFocus = (event) => {
+    event.preventDefault();
+  };
+  temporaryChatBtn.addEventListener('pointerdown', preserveTemporaryChatButtonFocus);
+  temporaryChatBtn.addEventListener('mousedown', preserveTemporaryChatButtonFocus);
+  temporaryChatBtn.addEventListener('click', temporaryChatAllProviders);
 
   // Settings button
   document.getElementById('settings-btn').addEventListener('click', () => {

--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -46,6 +46,7 @@ let sendFocusHardTimeoutIds = new Map();
 let tempChatRetryTimerIds = new Map();
 let tempChatCleanupTimerId = null;
 let tempChatPendingPanelIds = new Set();
+let isTemporaryChatModeEnabled = false;
 let currentGoogleProviderMode = DEFAULT_GOOGLE_PROVIDER_MODE;
 
 // 提示词编辑器状态
@@ -70,6 +71,17 @@ const PANELIZE_TEMP_CHAT_ENABLED = 'PANELIZE_TEMP_CHAT_ENABLED';
 const TEMP_CHAT_RETRY_DELAYS = [1200, 2500, 4000];
 const TEMP_CHAT_OPERATION_TIMEOUT_MS = 5000;
 const TEMP_CHAT_SUPPORTED_PROVIDERS = new Set(['chatgpt', 'gemini', 'claude', 'grok']);
+const TEMP_CHAT_URLS = {
+  chatgpt: 'https://chatgpt.com/?temporary-chat=true',
+  claude: 'https://claude.ai/new?incognito',
+  grok: 'https://grok.com/c#private'
+};
+const TEMP_CHAT_NORMAL_URLS = {
+  chatgpt: 'https://chatgpt.com/',
+  claude: 'https://claude.ai/new',
+  gemini: 'https://gemini.google.com/',
+  grok: 'https://grok.com/'
+};
 const LAYOUT_PANEL_COUNTS = {
   '1x1': 1,
   '1x2': 2,
@@ -117,6 +129,7 @@ async function init() {
 
   // Setup event listeners
   setupEventListeners();
+  updateTemporaryChatButtonState();
   focusUnifiedInput({ force: true });
 
   isInitialized = true;
@@ -160,6 +173,29 @@ function isTemporaryChatSupportedProvider(providerId) {
   return TEMP_CHAT_SUPPORTED_PROVIDERS.has(providerId);
 }
 
+function isUrlDrivenTemporaryChatProvider(providerId) {
+  return Object.prototype.hasOwnProperty.call(TEMP_CHAT_URLS, providerId);
+}
+
+function getTemporaryChatUrl(providerId) {
+  return TEMP_CHAT_URLS[providerId] || null;
+}
+
+function getTemporaryChatNormalUrl(providerId) {
+  if (Object.prototype.hasOwnProperty.call(TEMP_CHAT_NORMAL_URLS, providerId)) {
+    return TEMP_CHAT_NORMAL_URLS[providerId];
+  }
+
+  const provider = getProviderById(providerId);
+  if (!provider) {
+    return '';
+  }
+
+  return isGoogleProvider(providerId)
+    ? getGoogleProviderUrl(currentGoogleProviderMode)
+    : provider.url;
+}
+
 function getPanelProviderMode(panel) {
   return isGoogleProvider(panel.providerId) ? currentGoogleProviderMode : null;
 }
@@ -168,6 +204,10 @@ function getProviderFrameUrl(providerId) {
   const provider = getProviderById(providerId);
   if (!provider) {
     return '';
+  }
+
+  if (isTemporaryChatModeEnabled && isUrlDrivenTemporaryChatProvider(providerId)) {
+    return getTemporaryChatUrl(providerId);
   }
 
   return isGoogleProvider(providerId)
@@ -255,7 +295,7 @@ function showPanelLoadingState(panelEl, provider) {
   loadingEl.innerHTML = `<img src="${provider.icon}" alt="${provider.name}" class="loading-icon"><span class="loading-text">Loading ${provider.name}...</span>`;
 }
 
-function reloadPanelIframe(panel) {
+function reloadPanelIframe(panel, overrideUrl = null) {
   const panelEl = document.getElementById(panel.id);
   const provider = getProviderById(panel.providerId);
   if (!panelEl || !provider) {
@@ -269,7 +309,7 @@ function reloadPanelIframe(panel) {
 
   showPanelLoadingState(panelEl, provider);
   loadingIframeCount++;
-  iframe.src = getProviderFrameUrl(panel.providerId);
+  iframe.src = overrideUrl || getProviderFrameUrl(panel.providerId);
   panel.iframe = iframe;
 }
 
@@ -378,6 +418,21 @@ function setTemporaryChatButtonDisabled(disabled) {
   }
 }
 
+function updateTemporaryChatButtonState() {
+  const temporaryChatBtn = document.getElementById('temporary-chat-btn');
+  if (!temporaryChatBtn) {
+    return;
+  }
+
+  temporaryChatBtn.classList.toggle('active', isTemporaryChatModeEnabled);
+  temporaryChatBtn.setAttribute('aria-pressed', isTemporaryChatModeEnabled ? 'true' : 'false');
+}
+
+function setTemporaryChatModeEnabled(enabled) {
+  isTemporaryChatModeEnabled = Boolean(enabled);
+  updateTemporaryChatButtonState();
+}
+
 function clearTemporaryChatRetriesForPanel(panelId) {
   const timerIds = tempChatRetryTimerIds.get(panelId) || [];
   timerIds.forEach(timerId => clearTimeout(timerId));
@@ -399,6 +454,16 @@ function cancelTemporaryChatActivation({ restoreButton = true } = {}) {
   if (restoreButton) {
     setTemporaryChatButtonDisabled(false);
   }
+}
+
+function startTemporaryChatActivationForPanel(panel) {
+  if (!panel || panel.providerId !== 'gemini' || !panel.iframe || !panel.iframe.contentWindow) {
+    return;
+  }
+
+  clearTemporaryChatRetriesForPanel(panel.id);
+  tempChatPendingPanelIds.add(panel.id);
+  TEMP_CHAT_RETRY_DELAYS.forEach(delay => scheduleTemporaryChatRetry(panel, delay));
 }
 
 function isUnifiedInputOrNewChatControl(target) {
@@ -1026,6 +1091,9 @@ async function addPanel(providerId) {
   loadingIframeCount++;
   iframe.addEventListener('load', () => {
     loadingEl.classList.add('hidden');
+    if (isTemporaryChatModeEnabled && panel.providerId === 'gemini') {
+      startTemporaryChatActivationForPanel(panel);
+    }
     setTimeout(() => {
       loadingIframeCount = Math.max(0, loadingIframeCount - 1);
     }, LOAD_GRACE_PERIOD);
@@ -1447,7 +1515,29 @@ async function newChatAllProviders() {
   // Disable button during operation
   newChatBtn.disabled = true;
 
-  postNewChatToAllPanels();
+  if (isTemporaryChatModeEnabled) {
+    cancelTemporaryChatActivation({ restoreButton: false });
+    setTemporaryChatModeEnabled(false);
+
+    panels.forEach(panel => {
+      if (isTemporaryChatSupportedProvider(panel.providerId)) {
+        reloadPanelIframe(panel, getTemporaryChatNormalUrl(panel.providerId));
+        return;
+      }
+
+      if (panel.iframe && panel.iframe.contentWindow) {
+        panel.iframe.contentWindow.postMessage({
+          type: 'NEW_CHAT',
+          providerMode: getPanelProviderMode(panel),
+          context: 'multi-panel'
+        }, '*');
+      }
+    });
+
+    setTemporaryChatButtonDisabled(false);
+  } else {
+    postNewChatToAllPanels();
+  }
 
   restoreUnifiedInputFocusAfterNewChat();
   showToast('New chat created for all AIs');
@@ -1478,18 +1568,58 @@ function scheduleTemporaryChatRetry(panel, delay) {
 }
 
 async function temporaryChatAllProviders() {
+  if (isTemporaryChatModeEnabled) {
+    cancelTemporaryChatActivation({ restoreButton: false });
+    setTemporaryChatModeEnabled(false);
+    setTemporaryChatButtonDisabled(true);
+
+    panels.forEach(panel => {
+      if (isTemporaryChatSupportedProvider(panel.providerId)) {
+        reloadPanelIframe(panel, getTemporaryChatNormalUrl(panel.providerId));
+      }
+    });
+
+    restoreUnifiedInputFocusAfterNewChat();
+    showToast('Temporary chat disabled');
+
+    setTimeout(() => {
+      setTemporaryChatButtonDisabled(false);
+    }, 1000);
+    return;
+  }
+
   cancelTemporaryChatActivation({ restoreButton: false });
+  setTemporaryChatModeEnabled(true);
   setTemporaryChatButtonDisabled(true);
 
-  postNewChatToAllPanels();
-  restoreUnifiedInputFocusAfterNewChat();
+  panels.forEach(panel => {
+    if (panel.providerId === 'gemini') {
+      if (panel.iframe && panel.iframe.contentWindow) {
+        panel.iframe.contentWindow.postMessage({
+          type: 'NEW_CHAT',
+          providerMode: getPanelProviderMode(panel),
+          context: 'multi-panel'
+        }, '*');
+      }
+      startTemporaryChatActivationForPanel(panel);
+      return;
+    }
 
-  panels
-    .filter(panel => isTemporaryChatSupportedProvider(panel.providerId))
-    .forEach(panel => {
-      tempChatPendingPanelIds.add(panel.id);
-      TEMP_CHAT_RETRY_DELAYS.forEach(delay => scheduleTemporaryChatRetry(panel, delay));
-    });
+    if (isUrlDrivenTemporaryChatProvider(panel.providerId)) {
+      reloadPanelIframe(panel, getTemporaryChatUrl(panel.providerId));
+      return;
+    }
+
+    if (panel.iframe && panel.iframe.contentWindow) {
+      panel.iframe.contentWindow.postMessage({
+        type: 'NEW_CHAT',
+        providerMode: getPanelProviderMode(panel),
+        context: 'multi-panel'
+      }, '*');
+    }
+  });
+
+  restoreUnifiedInputFocusAfterNewChat();
 
   tempChatCleanupTimerId = setTimeout(() => {
     cancelTemporaryChatActivation();

--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -33,7 +33,7 @@ import {
 let currentLayout = '1x3';
 let panels = []; // Array of { id, providerId, iframe, state }
 let uploadedImages = []; // Array of uploaded images { id, name, type, dataUrl }
-let loadingIframeCount = 0; // Track iframes still loading, used for focus protection
+let loadingPanelIds = new Set(); // Track iframes still loading, used for focus protection
 let newChatFocusRestoreTimerIds = [];
 let isRestoringFocusAfterNewChat = false;
 let sendFocusRestoreTimerIds = [];
@@ -158,7 +158,7 @@ function focusUnifiedInput({ force = false } = {}) {
 }
 
 function shouldPreserveUnifiedInputFocus() {
-  return loadingIframeCount > 0 || isRestoringFocusAfterNewChat || isRestoringFocusAfterSend;
+  return loadingPanelIds.size > 0 || isRestoringFocusAfterNewChat || isRestoringFocusAfterSend;
 }
 
 function isGoogleProvider(providerId) {
@@ -308,7 +308,7 @@ function reloadPanelIframe(panel, overrideUrl = null) {
   }
 
   showPanelLoadingState(panelEl, provider);
-  loadingIframeCount++;
+  loadingPanelIds.add(panel.id);
   iframe.src = overrideUrl || getProviderFrameUrl(panel.providerId);
   panel.iframe = iframe;
 }
@@ -1088,20 +1088,21 @@ async function addPanel(providerId) {
   // Handle iframe load
   // Grace period after load to catch AI pages that auto-focus after JS init
   const LOAD_GRACE_PERIOD = 3000;
-  loadingIframeCount++;
+  loadingPanelIds.add(panelId);
   iframe.addEventListener('load', () => {
     loadingEl.classList.add('hidden');
-    if (isTemporaryChatModeEnabled && panel.providerId === 'gemini') {
+    const panel = panels.find(p => p.id === panelId);
+    if (isTemporaryChatModeEnabled && panel && panel.providerId === 'gemini') {
       startTemporaryChatActivationForPanel(panel);
     }
     setTimeout(() => {
-      loadingIframeCount = Math.max(0, loadingIframeCount - 1);
+      loadingPanelIds.delete(panelId);
     }, LOAD_GRACE_PERIOD);
   });
 
   iframe.addEventListener('error', () => {
     loadingEl.innerHTML = `<img src="${provider.icon}" alt="${provider.name}" class="loading-icon"><span class="loading-text">Failed to load ${provider.name}</span>`;
-    loadingIframeCount = Math.max(0, loadingIframeCount - 1);
+    loadingPanelIds.delete(panelId);
   });
 
   // Add to panels array
@@ -1131,8 +1132,9 @@ function removePanel(panelId) {
     panelEl.remove();
   }
 
-  // Remove from array
+  // Remove from arrays and sets
   panels.splice(panelIndex, 1);
+  loadingPanelIds.delete(panelId);
 
   // Auto-shrink layout if applicable
   const shrunkLayout = getAutoShrunkLayout(currentLayout, panels.length);

--- a/tests/e2e/temporary-chat.e2e.test.js
+++ b/tests/e2e/temporary-chat.e2e.test.js
@@ -56,6 +56,8 @@ test.describe('Temporary Chat E2E', () => {
     expect(newChatMessages).toHaveLength(1);
     expect(enableMessages).toHaveLength(2);
     expect(enableMessages.map(entry => entry.delay)).toEqual([1200, 2500]);
+    expect(debugState.isTemporaryChatModeEnabled).toBe(true);
+    expect(debugState.temporaryChatButtonActive).toBe(true);
     expect(debugState.pendingPanelCount).toBe(0);
     expect(debugState.temporaryChatButtonDisabled).toBe(false);
 
@@ -81,7 +83,53 @@ test.describe('Temporary Chat E2E', () => {
 
     expect(newChatMessages).toHaveLength(1);
     expect(enableMessages).toHaveLength(0);
+    expect(debugState.isTemporaryChatModeEnabled).toBe(true);
+    expect(debugState.temporaryChatButtonActive).toBe(true);
     expect(debugState.pendingPanelCount).toBe(0);
     expect(debugState.temporaryChatButtonDisabled).toBe(false);
+  });
+
+  test('clicking the temporary chat button again disables temporary mode', async () => {
+    await page.evaluate(async () => {
+      window.setControlledIframeProvider('gemini');
+      await window.addControlledIframe();
+      window.setTempChatSuccessTimeline([1200]);
+    });
+
+    await page.click('#temporary-chat-btn');
+    await page.waitForTimeout(5200);
+    await page.click('#temporary-chat-btn');
+    await page.waitForTimeout(1200);
+
+    const debugState = await page.evaluate(() => window.getTemporaryChatDebugState());
+    const disableMessages = debugState.messageLog.filter(entry => entry.type === 'DISABLE_TEMP_CHAT');
+
+    expect(debugState.isTemporaryChatModeEnabled).toBe(false);
+    expect(debugState.temporaryChatButtonActive).toBe(false);
+    expect(disableMessages).toEqual([
+      expect.objectContaining({ providerId: 'gemini', source: 'toggle' })
+    ]);
+  });
+
+  test('new chat disables temporary mode when it is active', async () => {
+    await page.evaluate(async () => {
+      window.setControlledIframeProvider('gemini');
+      await window.addControlledIframe();
+      window.setTempChatSuccessTimeline([1200]);
+    });
+
+    await page.click('#temporary-chat-btn');
+    await page.waitForTimeout(5200);
+    await page.click('#new-chat-btn');
+    await page.waitForTimeout(200);
+
+    const debugState = await page.evaluate(() => window.getTemporaryChatDebugState());
+    const disableMessages = debugState.messageLog.filter(entry => entry.type === 'DISABLE_TEMP_CHAT');
+
+    expect(debugState.isTemporaryChatModeEnabled).toBe(false);
+    expect(debugState.temporaryChatButtonActive).toBe(false);
+    expect(disableMessages).toEqual([
+      expect.objectContaining({ providerId: 'gemini', source: 'new-chat' })
+    ]);
   });
 });

--- a/tests/e2e/temporary-chat.e2e.test.js
+++ b/tests/e2e/temporary-chat.e2e.test.js
@@ -1,0 +1,87 @@
+import { test, expect, chromium } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const EXTENSION_PATH = path.resolve(__dirname, '../..');
+
+test.describe('Temporary Chat E2E', () => {
+  test.setTimeout(30000);
+
+  let browser;
+  let context;
+  let page;
+
+  test.beforeAll(async () => {
+    browser = await chromium.launch({
+      headless: false,
+      args: ['--no-sandbox', '--disable-setuid-sandbox']
+    });
+    context = await browser.newContext({
+      viewport: { width: 1024, height: 768 }
+    });
+  });
+
+  test.beforeEach(async () => {
+    page = await context.newPage();
+    await page.goto(`file://${EXTENSION_PATH}/tests/e2e/test-temporary-chat.html`);
+    await page.waitForLoadState('networkidle');
+  });
+
+  test.afterEach(async () => {
+    await page.close();
+  });
+
+  test.afterAll(async () => {
+    await browser.close().catch(() => {});
+  });
+
+  test('retries temporary chat for supported providers and stops after success', async () => {
+    await page.evaluate(async () => {
+      window.setControlledIframeProvider('gemini');
+      await window.addControlledIframe();
+      window.setTempChatSuccessTimeline([2500]);
+    });
+
+    await page.click('#unified-input');
+    await page.waitForTimeout(50);
+    await page.click('#temporary-chat-btn');
+    await page.waitForTimeout(5200);
+
+    const debugState = await page.evaluate(() => window.getTemporaryChatDebugState());
+    const newChatMessages = debugState.messageLog.filter(entry => entry.type === 'NEW_CHAT');
+    const enableMessages = debugState.messageLog.filter(entry => entry.type === 'ENABLE_TEMP_CHAT');
+
+    expect(newChatMessages).toHaveLength(1);
+    expect(enableMessages).toHaveLength(2);
+    expect(enableMessages.map(entry => entry.delay)).toEqual([1200, 2500]);
+    expect(debugState.pendingPanelCount).toBe(0);
+    expect(debugState.temporaryChatButtonDisabled).toBe(false);
+
+    const activeId = await page.evaluate(() => window.getActiveElementId());
+    expect(activeId).toBe('unified-input');
+  });
+
+  test('skips unsupported providers without sending temp chat messages', async () => {
+    await page.evaluate(async () => {
+      window.setControlledIframeProvider('google');
+      await window.addControlledIframe();
+      window.setTempChatSuccessTimeline([]);
+    });
+
+    await page.click('#unified-input');
+    await page.waitForTimeout(50);
+    await page.click('#temporary-chat-btn');
+    await page.waitForTimeout(5200);
+
+    const debugState = await page.evaluate(() => window.getTemporaryChatDebugState());
+    const newChatMessages = debugState.messageLog.filter(entry => entry.type === 'NEW_CHAT');
+    const enableMessages = debugState.messageLog.filter(entry => entry.type === 'ENABLE_TEMP_CHAT');
+
+    expect(newChatMessages).toHaveLength(1);
+    expect(enableMessages).toHaveLength(0);
+    expect(debugState.pendingPanelCount).toBe(0);
+    expect(debugState.temporaryChatButtonDisabled).toBe(false);
+  });
+});

--- a/tests/e2e/test-temporary-chat.html
+++ b/tests/e2e/test-temporary-chat.html
@@ -15,12 +15,14 @@
   <label for="unified-input"><strong>Unified Input:</strong></label><br>
   <textarea id="unified-input" rows="2" placeholder="Type here..."></textarea>
   <br>
+  <button id="new-chat-btn" type="button">New Chat for All</button>
   <button id="temporary-chat-btn" type="button">Temporary Chat for All</button>
 
   <div id="iframe-container"></div>
 
   <script>
     const inputTextarea = document.getElementById('unified-input');
+    const newChatBtn = document.getElementById('new-chat-btn');
     const temporaryChatBtn = document.getElementById('temporary-chat-btn');
     const MULTI_PANEL_PROVIDER_STATUS_CONTEXT = 'multi-panel-provider-status';
     const PANELIZE_TEMP_CHAT_ENABLED = 'PANELIZE_TEMP_CHAT_ENABLED';
@@ -33,6 +35,7 @@
     let tempChatRetryTimerIds = new Map();
     let tempChatCleanupTimerId = null;
     let tempChatPendingPanelIds = new Set();
+    let isTemporaryChatModeEnabled = false;
     let controlledIframeProviderId = 'chatgpt';
     let tempChatSuccessTimeline = [];
     let tempChatMessageLog = [];
@@ -118,6 +121,16 @@
       temporaryChatBtn.disabled = false;
     }
 
+    function updateTemporaryChatButtonState() {
+      temporaryChatBtn.classList.toggle('active', isTemporaryChatModeEnabled);
+      temporaryChatBtn.setAttribute('aria-pressed', isTemporaryChatModeEnabled ? 'true' : 'false');
+    }
+
+    function setTemporaryChatModeEnabled(enabled) {
+      isTemporaryChatModeEnabled = Boolean(enabled);
+      updateTemporaryChatButtonState();
+    }
+
     function postNewChatToAllPanels() {
       const panel = getControlledIframePanel();
       if (!panel) {
@@ -142,6 +155,15 @@
       tempChatRetryTimerIds.set(panel.id, timerIds);
     }
 
+    function disableTemporaryChatForSupportedPanels(source) {
+      const panel = getControlledIframePanel();
+      if (!panel || !isTemporaryChatSupportedProvider(panel.providerId)) {
+        return;
+      }
+
+      tempChatMessageLog.push({ type: 'DISABLE_TEMP_CHAT', providerId: panel.providerId, source });
+    }
+
     function scheduleTempChatSuccessTimeline() {
       const panel = getControlledIframePanel();
       if (!panel || !panel.iframe.contentWindow) {
@@ -164,7 +186,20 @@
     }
 
     function temporaryChatAllProviders() {
+      if (isTemporaryChatModeEnabled) {
+        cancelTemporaryChatActivation();
+        setTemporaryChatModeEnabled(false);
+        temporaryChatBtn.disabled = true;
+        disableTemporaryChatForSupportedPanels('toggle');
+        restoreUnifiedInputFocusAfterNewChat();
+        setTimeout(() => {
+          temporaryChatBtn.disabled = false;
+        }, 1000);
+        return;
+      }
+
       cancelTemporaryChatActivation();
+      setTemporaryChatModeEnabled(true);
       temporaryChatBtn.disabled = true;
       postNewChatToAllPanels();
       restoreUnifiedInputFocusAfterNewChat();
@@ -181,6 +216,19 @@
       }, TEMP_CHAT_OPERATION_TIMEOUT_MS);
     }
 
+    function newChatAllProviders() {
+      if (isTemporaryChatModeEnabled) {
+        cancelTemporaryChatActivation();
+        setTemporaryChatModeEnabled(false);
+        disableTemporaryChatForSupportedPanels('new-chat');
+      } else {
+        postNewChatToAllPanels();
+      }
+
+      restoreUnifiedInputFocusAfterNewChat();
+    }
+
+    newChatBtn.addEventListener('click', newChatAllProviders);
     temporaryChatBtn.addEventListener('pointerdown', (event) => event.preventDefault());
     temporaryChatBtn.addEventListener('mousedown', (event) => event.preventDefault());
     temporaryChatBtn.addEventListener('click', temporaryChatAllProviders);
@@ -236,8 +284,10 @@
 
     window.getTemporaryChatDebugState = function() {
       return {
+        isTemporaryChatModeEnabled,
         pendingPanelCount: tempChatPendingPanelIds.size,
         temporaryChatButtonDisabled: temporaryChatBtn.disabled,
+        temporaryChatButtonActive: temporaryChatBtn.classList.contains('active'),
         messageLog: tempChatMessageLog.slice()
       };
     };

--- a/tests/e2e/test-temporary-chat.html
+++ b/tests/e2e/test-temporary-chat.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Temporary Chat Test Harness</title>
+  <style>
+    body { font-family: sans-serif; margin: 20px; }
+    textarea { width: 400px; padding: 8px; font-size: 16px; }
+    iframe { width: 400px; height: 150px; border: 1px solid #999; margin-top: 10px; display: block; }
+  </style>
+</head>
+<body>
+  <h1>Temporary Chat Test Harness</h1>
+
+  <label for="unified-input"><strong>Unified Input:</strong></label><br>
+  <textarea id="unified-input" rows="2" placeholder="Type here..."></textarea>
+  <br>
+  <button id="temporary-chat-btn" type="button">Temporary Chat for All</button>
+
+  <div id="iframe-container"></div>
+
+  <script>
+    const inputTextarea = document.getElementById('unified-input');
+    const temporaryChatBtn = document.getElementById('temporary-chat-btn');
+    const MULTI_PANEL_PROVIDER_STATUS_CONTEXT = 'multi-panel-provider-status';
+    const PANELIZE_TEMP_CHAT_ENABLED = 'PANELIZE_TEMP_CHAT_ENABLED';
+    const TEMP_CHAT_RETRY_DELAYS = [1200, 2500, 4000];
+    const TEMP_CHAT_OPERATION_TIMEOUT_MS = 5000;
+    const TEMP_CHAT_SUPPORTED_PROVIDERS = new Set(['chatgpt', 'gemini', 'claude', 'grok']);
+
+    let newChatFocusRestoreTimerIds = [];
+    let isRestoringFocusAfterNewChat = false;
+    let tempChatRetryTimerIds = new Map();
+    let tempChatCleanupTimerId = null;
+    let tempChatPendingPanelIds = new Set();
+    let controlledIframeProviderId = 'chatgpt';
+    let tempChatSuccessTimeline = [];
+    let tempChatMessageLog = [];
+
+    function focusUnifiedInput(options = {}) {
+      const force = Boolean(options.force);
+      const active = document.activeElement;
+      const shouldFocus = force || !active || active.tagName === 'IFRAME' || active === document.body;
+      if (!shouldFocus) {
+        return;
+      }
+
+      requestAnimationFrame(() => {
+        try {
+          inputTextarea.focus({ preventScroll: true });
+        } catch {
+          inputTextarea.focus();
+        }
+      });
+    }
+
+    function cancelUnifiedInputFocusRestore() {
+      newChatFocusRestoreTimerIds.forEach(timerId => clearTimeout(timerId));
+      newChatFocusRestoreTimerIds = [];
+      isRestoringFocusAfterNewChat = false;
+    }
+
+    function restoreUnifiedInputFocusAfterNewChat() {
+      cancelUnifiedInputFocusRestore();
+      isRestoringFocusAfterNewChat = true;
+
+      [0, 80, 200, 400, 800, 1000, 1200, 1500].forEach((delay, index, delays) => {
+        const timerId = setTimeout(() => {
+          if (!isRestoringFocusAfterNewChat) {
+            return;
+          }
+
+          focusUnifiedInput({ force: true });
+
+          if (index === delays.length - 1) {
+            cancelUnifiedInputFocusRestore();
+          }
+        }, delay);
+
+        newChatFocusRestoreTimerIds.push(timerId);
+      });
+    }
+
+    function isTemporaryChatSupportedProvider(providerId) {
+      return TEMP_CHAT_SUPPORTED_PROVIDERS.has(providerId);
+    }
+
+    function getControlledIframePanel() {
+      const iframe = document.querySelector('#iframe-container iframe');
+      if (!iframe || !iframe.contentWindow) {
+        return null;
+      }
+
+      return {
+        id: 'controlled-panel',
+        providerId: controlledIframeProviderId,
+        iframe
+      };
+    }
+
+    function clearTemporaryChatRetriesForPanel(panelId) {
+      const timerIds = tempChatRetryTimerIds.get(panelId) || [];
+      timerIds.forEach(timerId => clearTimeout(timerId));
+      tempChatRetryTimerIds.delete(panelId);
+    }
+
+    function cancelTemporaryChatActivation() {
+      tempChatRetryTimerIds.forEach(timerIds => {
+        timerIds.forEach(timerId => clearTimeout(timerId));
+      });
+      tempChatRetryTimerIds.clear();
+      tempChatPendingPanelIds.clear();
+
+      if (typeof tempChatCleanupTimerId === 'number') {
+        clearTimeout(tempChatCleanupTimerId);
+      }
+      tempChatCleanupTimerId = null;
+      temporaryChatBtn.disabled = false;
+    }
+
+    function postNewChatToAllPanels() {
+      const panel = getControlledIframePanel();
+      if (!panel) {
+        return;
+      }
+
+      tempChatMessageLog.push({ type: 'NEW_CHAT', providerId: panel.providerId });
+    }
+
+    function scheduleTemporaryChatRetry(panel, delay) {
+      const timerId = setTimeout(() => {
+        if (!tempChatPendingPanelIds.has(panel.id)) {
+          return;
+        }
+
+        focusUnifiedInput({ force: true });
+        tempChatMessageLog.push({ type: 'ENABLE_TEMP_CHAT', providerId: panel.providerId, delay });
+      }, delay);
+
+      const timerIds = tempChatRetryTimerIds.get(panel.id) || [];
+      timerIds.push(timerId);
+      tempChatRetryTimerIds.set(panel.id, timerIds);
+    }
+
+    function scheduleTempChatSuccessTimeline() {
+      const panel = getControlledIframePanel();
+      if (!panel || !panel.iframe.contentWindow) {
+        return;
+      }
+
+      tempChatSuccessTimeline.forEach((delay) => {
+        setTimeout(() => {
+          if (!tempChatPendingPanelIds.has(panel.id) || !panel.iframe.contentWindow.reportPanelizeStatus) {
+            return;
+          }
+
+          panel.iframe.contentWindow.reportPanelizeStatus({
+            type: PANELIZE_TEMP_CHAT_ENABLED,
+            provider: panel.providerId,
+            context: MULTI_PANEL_PROVIDER_STATUS_CONTEXT
+          });
+        }, delay);
+      });
+    }
+
+    function temporaryChatAllProviders() {
+      cancelTemporaryChatActivation();
+      temporaryChatBtn.disabled = true;
+      postNewChatToAllPanels();
+      restoreUnifiedInputFocusAfterNewChat();
+
+      const panel = getControlledIframePanel();
+      if (panel && isTemporaryChatSupportedProvider(panel.providerId)) {
+        tempChatPendingPanelIds.add(panel.id);
+        TEMP_CHAT_RETRY_DELAYS.forEach(delay => scheduleTemporaryChatRetry(panel, delay));
+        scheduleTempChatSuccessTimeline();
+      }
+
+      tempChatCleanupTimerId = setTimeout(() => {
+        cancelTemporaryChatActivation();
+      }, TEMP_CHAT_OPERATION_TIMEOUT_MS);
+    }
+
+    temporaryChatBtn.addEventListener('pointerdown', (event) => event.preventDefault());
+    temporaryChatBtn.addEventListener('mousedown', (event) => event.preventDefault());
+    temporaryChatBtn.addEventListener('click', temporaryChatAllProviders);
+
+    inputTextarea.addEventListener('blur', () => {
+      if (isRestoringFocusAfterNewChat) {
+        focusUnifiedInput();
+      }
+    });
+
+    window.addEventListener('message', (event) => {
+      const data = event.data;
+      if (!data || data.context !== MULTI_PANEL_PROVIDER_STATUS_CONTEXT || data.type !== PANELIZE_TEMP_CHAT_ENABLED) {
+        return;
+      }
+
+      const panel = getControlledIframePanel();
+      if (!panel || event.source !== panel.iframe.contentWindow || data.provider !== panel.providerId) {
+        return;
+      }
+
+      clearTemporaryChatRetriesForPanel(panel.id);
+      tempChatPendingPanelIds.delete(panel.id);
+    });
+
+    focusUnifiedInput({ force: true });
+
+    window.addControlledIframe = function() {
+      return new Promise((resolve) => {
+        const iframe = document.createElement('iframe');
+        iframe.srcdoc = `<html><body><input id="ai-input" type="text"><script>
+          window.reportPanelizeStatus = function(payload) {
+            window.parent.postMessage(payload, '*');
+          };
+        <\/script></body></html>`;
+        iframe.addEventListener('load', () => resolve(true));
+        iframe.addEventListener('error', () => resolve(false));
+        document.getElementById('iframe-container').appendChild(iframe);
+      });
+    };
+
+    window.setControlledIframeProvider = function(providerId) {
+      controlledIframeProviderId = providerId || 'chatgpt';
+    };
+
+    window.setTempChatSuccessTimeline = function(delays) {
+      tempChatSuccessTimeline = Array.isArray(delays) ? delays.map(delay => Number(delay) || 0) : [];
+    };
+
+    window.getActiveElementId = function() {
+      return document.activeElement ? document.activeElement.id : 'null';
+    };
+
+    window.getTemporaryChatDebugState = function() {
+      return {
+        pendingPanelCount: tempChatPendingPanelIds.size,
+        temporaryChatButtonDisabled: temporaryChatBtn.disabled,
+        messageLog: tempChatMessageLog.slice()
+      };
+    };
+  </script>
+</body>
+</html>

--- a/tests/temporary-chat-content-script.test.js
+++ b/tests/temporary-chat-content-script.test.js
@@ -1,0 +1,129 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const contentScriptSource = readFileSync(
+  resolve(process.cwd(), 'content-scripts/text-injection-all-providers.js'),
+  'utf8'
+);
+
+function dispatchMultiPanelMessage(payload) {
+  window.dispatchEvent(new MessageEvent('message', { data: payload }));
+}
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function markVisible(element) {
+  Object.defineProperty(element, 'offsetParent', {
+    configurable: true,
+    get: () => document.body,
+  });
+}
+
+function getTemporaryChatEnabledCalls(postMessageSpy) {
+  return postMessageSpy.mock.calls
+    .map(call => call[0])
+    .filter(payload => payload?.type === 'PANELIZE_TEMP_CHAT_ENABLED' && payload?.context === 'multi-panel-provider-status');
+}
+
+describe('temporary chat content script', () => {
+  beforeAll(() => {
+    window.eval(contentScriptSource);
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      value: { postMessage: vi.fn() },
+    });
+    document.body.innerHTML = '';
+  });
+
+  it('enables temporary chat for ChatGPT', async () => {
+    window.happyDOM.setURL('https://chatgpt.com/');
+    document.body.innerHTML = '<button aria-label="Turn on temporary chat">Temp</button>';
+    const button = document.querySelector('button');
+    markVisible(button);
+
+    const clickSpy = vi.fn();
+    button.addEventListener('click', clickSpy);
+
+    dispatchMultiPanelMessage({ type: 'ENABLE_TEMP_CHAT', context: 'multi-panel' });
+    await wait(50);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(getTemporaryChatEnabledCalls(window.parent.postMessage)).toEqual([
+      expect.objectContaining({ provider: 'chatgpt' })
+    ]);
+  });
+
+  it('polls briefly for the Gemini temporary chat button', async () => {
+    window.happyDOM.setURL('https://gemini.google.com/app');
+
+    setTimeout(() => {
+      const button = document.createElement('button');
+      button.setAttribute('data-test-id', 'temp-chat-button');
+      markVisible(button);
+      button.addEventListener('click', () => {
+        button.dataset.clicked = 'true';
+      });
+      document.body.appendChild(button);
+    }, 250);
+
+    dispatchMultiPanelMessage({ type: 'ENABLE_TEMP_CHAT', context: 'multi-panel' });
+    await wait(500);
+
+    expect(document.querySelector('button')?.dataset.clicked).toBe('true');
+    expect(getTemporaryChatEnabledCalls(window.parent.postMessage)).toEqual([
+      expect.objectContaining({ provider: 'gemini' })
+    ]);
+  });
+
+  it('enables incognito for Claude', async () => {
+    window.happyDOM.setURL('https://claude.ai/new');
+    document.body.innerHTML = '<button aria-label="Use incognito">Incognito</button>';
+    const button = document.querySelector('button');
+    markVisible(button);
+
+    const clickSpy = vi.fn();
+    button.addEventListener('click', clickSpy);
+
+    dispatchMultiPanelMessage({ type: 'ENABLE_TEMP_CHAT', context: 'multi-panel' });
+    await wait(50);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(getTemporaryChatEnabledCalls(window.parent.postMessage)).toEqual([
+      expect.objectContaining({ provider: 'claude' })
+    ]);
+  });
+
+  it('enables private chat for Grok', async () => {
+    window.happyDOM.setURL('https://grok.com/');
+    document.body.innerHTML = '<a href="/c#private" aria-label="Switch to Private Chat">Private</a>';
+    const link = document.querySelector('a');
+    markVisible(link);
+
+    const clickSpy = vi.fn((event) => event.preventDefault());
+    link.addEventListener('click', clickSpy);
+
+    dispatchMultiPanelMessage({ type: 'ENABLE_TEMP_CHAT', context: 'multi-panel' });
+    await wait(50);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(getTemporaryChatEnabledCalls(window.parent.postMessage)).toEqual([
+      expect.objectContaining({ provider: 'grok' })
+    ]);
+  });
+
+  it('silently skips unsupported providers', async () => {
+    window.happyDOM.setURL('https://www.google.com/');
+
+    dispatchMultiPanelMessage({ type: 'ENABLE_TEMP_CHAT', context: 'multi-panel' });
+    await wait(50);
+
+    expect(getTemporaryChatEnabledCalls(window.parent.postMessage)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a toolbar toggle to enable temporary chat for supported providers
- support turning temporary chat off and clearing it on new chat
- fix the iframe loading-state leak that kept unified-input focus protection stuck on

Fixes #32