### PR TITLE
fix: reset unsupported providers when temp chat is disabled

### DIFF
--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -200,6 +200,18 @@ function getPanelProviderMode(panel) {
   return isGoogleProvider(panel.providerId) ? currentGoogleProviderMode : null;
 }
 
+function postNewChatToPanel(panel) {
+  if (!panel || !panel.iframe || !panel.iframe.contentWindow) {
+    return;
+  }
+
+  panel.iframe.contentWindow.postMessage({
+    type: 'NEW_CHAT',
+    providerMode: getPanelProviderMode(panel),
+    context: 'multi-panel'
+  }, '*');
+}
+
 function getProviderFrameUrl(providerId) {
   const provider = getProviderById(providerId);
   if (!provider) {
@@ -1389,13 +1401,7 @@ async function sendToPanel(panel, text, images = [], autoSubmit = true, requestI
 
 function postNewChatToAllPanels() {
   panels.forEach(panel => {
-    if (panel.iframe && panel.iframe.contentWindow) {
-      panel.iframe.contentWindow.postMessage({
-        type: 'NEW_CHAT',
-        providerMode: getPanelProviderMode(panel),
-        context: 'multi-panel'
-      }, '*');
-    }
+    postNewChatToPanel(panel);
   });
 }
 
@@ -1527,13 +1533,7 @@ async function newChatAllProviders() {
         return;
       }
 
-      if (panel.iframe && panel.iframe.contentWindow) {
-        panel.iframe.contentWindow.postMessage({
-          type: 'NEW_CHAT',
-          providerMode: getPanelProviderMode(panel),
-          context: 'multi-panel'
-        }, '*');
-      }
+      postNewChatToPanel(panel);
     });
 
     setTemporaryChatButtonDisabled(false);
@@ -1578,7 +1578,10 @@ async function temporaryChatAllProviders() {
     panels.forEach(panel => {
       if (isTemporaryChatSupportedProvider(panel.providerId)) {
         reloadPanelIframe(panel, getTemporaryChatNormalUrl(panel.providerId));
+        return;
       }
+
+      postNewChatToPanel(panel);
     });
 
     restoreUnifiedInputFocusAfterNewChat();
@@ -1596,13 +1599,7 @@ async function temporaryChatAllProviders() {
 
   panels.forEach(panel => {
     if (panel.providerId === 'gemini') {
-      if (panel.iframe && panel.iframe.contentWindow) {
-        panel.iframe.contentWindow.postMessage({
-          type: 'NEW_CHAT',
-          providerMode: getPanelProviderMode(panel),
-          context: 'multi-panel'
-        }, '*');
-      }
+      postNewChatToPanel(panel);
       startTemporaryChatActivationForPanel(panel);
       return;
     }
@@ -1612,13 +1609,7 @@ async function temporaryChatAllProviders() {
       return;
     }
 
-    if (panel.iframe && panel.iframe.contentWindow) {
-      panel.iframe.contentWindow.postMessage({
-        type: 'NEW_CHAT',
-        providerMode: getPanelProviderMode(panel),
-        context: 'multi-panel'
-      }, '*');
-    }
+    postNewChatToPanel(panel);
   });
 
   restoreUnifiedInputFocusAfterNewChat();

--- a/tests/e2e/temporary-chat.e2e.test.js
+++ b/tests/e2e/temporary-chat.e2e.test.js
@@ -111,6 +111,31 @@ test.describe('Temporary Chat E2E', () => {
     ]);
   });
 
+  test('disabling temporary mode also creates a new chat for unsupported providers', async () => {
+    await page.evaluate(async () => {
+      window.setControlledIframeProvider('kimi');
+      await window.addControlledIframe();
+      window.setTempChatSuccessTimeline([]);
+    });
+
+    await page.click('#temporary-chat-btn');
+    await page.waitForTimeout(5200);
+    await page.click('#temporary-chat-btn');
+    await page.waitForTimeout(1200);
+
+    const debugState = await page.evaluate(() => window.getTemporaryChatDebugState());
+    const newChatMessages = debugState.messageLog.filter(entry => entry.type === 'NEW_CHAT');
+    const disableMessages = debugState.messageLog.filter(entry => entry.type === 'DISABLE_TEMP_CHAT');
+
+    expect(debugState.isTemporaryChatModeEnabled).toBe(false);
+    expect(debugState.temporaryChatButtonActive).toBe(false);
+    expect(newChatMessages).toEqual([
+      expect.objectContaining({ providerId: 'kimi' }),
+      expect.objectContaining({ providerId: 'kimi' })
+    ]);
+    expect(disableMessages).toHaveLength(0);
+  });
+
   test('new chat disables temporary mode when it is active', async () => {
     await page.evaluate(async () => {
       window.setControlledIframeProvider('gemini');

--- a/tests/e2e/test-temporary-chat.html
+++ b/tests/e2e/test-temporary-chat.html
@@ -101,6 +101,15 @@
       };
     }
 
+    function postNewChatToPanel() {
+      const panel = getControlledIframePanel();
+      if (!panel) {
+        return;
+      }
+
+      tempChatMessageLog.push({ type: 'NEW_CHAT', providerId: panel.providerId });
+    }
+
     function clearTemporaryChatRetriesForPanel(panelId) {
       const timerIds = tempChatRetryTimerIds.get(panelId) || [];
       timerIds.forEach(timerId => clearTimeout(timerId));
@@ -132,12 +141,7 @@
     }
 
     function postNewChatToAllPanels() {
-      const panel = getControlledIframePanel();
-      if (!panel) {
-        return;
-      }
-
-      tempChatMessageLog.push({ type: 'NEW_CHAT', providerId: panel.providerId });
+      postNewChatToPanel();
     }
 
     function scheduleTemporaryChatRetry(panel, delay) {
@@ -190,7 +194,12 @@
         cancelTemporaryChatActivation();
         setTemporaryChatModeEnabled(false);
         temporaryChatBtn.disabled = true;
-        disableTemporaryChatForSupportedPanels('toggle');
+        const panel = getControlledIframePanel();
+        if (panel && isTemporaryChatSupportedProvider(panel.providerId)) {
+          disableTemporaryChatForSupportedPanels('toggle');
+        } else {
+          postNewChatToPanel();
+        }
         restoreUnifiedInputFocusAfterNewChat();
         setTimeout(() => {
           temporaryChatBtn.disabled = false;


### PR DESCRIPTION
## Summary
- reset unsupported providers with a fresh NEW_CHAT when temporary chat is turned off
- keep supported providers on the existing temporary-chat disable flow
- cover the unsupported-provider reset path in the temporary chat E2E harness

## Testing
- node --check multi-panel/multi-panel.js
- npx playwright test tests/e2e/temporary-chat.e2e.test.js