### PR TITLE
Preserve temporary mode on New Chat for All

### DIFF
--- a/content-scripts/text-injection-all-providers.js
+++ b/content-scripts/text-injection-all-providers.js
@@ -195,9 +195,7 @@
     kimi: [
       'a.new-chat-btn',
       'a[href="/"]',
-      '.sidebar a[href="/"]',
-      'button:has-text("新建会话")',
-      'a:has-text("新建会话")'
+      '.sidebar a[href="/"]'
     ],
     google: [
       'button[aria-label="New search"]',
@@ -265,10 +263,30 @@
   }
 
   function isVisibleElement(element) {
+    if (!element || element.offsetParent === null || element.getAttribute('aria-hidden') === 'true') {
+      return false;
+    }
+
+    const rect = typeof element.getBoundingClientRect === 'function'
+      ? element.getBoundingClientRect()
+      : null;
+
+    if (!rect) {
+      return true;
+    }
+
+    if (rect.width === 0 && rect.height === 0) {
+      return element.offsetParent !== null;
+    }
+
+    const viewportWidth = window.innerWidth || document.documentElement?.clientWidth || Number.POSITIVE_INFINITY;
+    const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || Number.POSITIVE_INFINITY;
+
     return Boolean(
-      element &&
-      element.offsetParent !== null &&
-      element.getAttribute('aria-hidden') !== 'true'
+      rect.bottom > 0 &&
+      rect.right > 0 &&
+      rect.top < viewportHeight &&
+      rect.left < viewportWidth
     );
   }
 
@@ -925,6 +943,60 @@
     return true;
   }
 
+  function isTemporaryChatControlActive(element) {
+    if (!element) {
+      return false;
+    }
+
+    if (element.getAttribute('aria-pressed') === 'true' || element.getAttribute('aria-checked') === 'true') {
+      return true;
+    }
+
+    const dataState = (element.dataset?.state || '').toLowerCase();
+    if (dataState === 'active' || dataState === 'on' || dataState === 'checked' || dataState === 'selected') {
+      return true;
+    }
+
+    const classTokens = element.classList
+      ? [...element.classList].map(token => token.toLowerCase())
+      : String(element.className || '')
+        .toLowerCase()
+        .split(/\s+/)
+        .filter(Boolean);
+
+    return ['active', 'selected', 'checked', 'toggled', 'enabled', 'on'].some(token => classTokens.includes(token));
+  }
+
+  function isGeminiTemporaryChatEnabled(control = null) {
+    const button = control ||
+      document.querySelector('button[data-test-id="temp-chat-button"]') ||
+      document.querySelector('button[aria-label="Temporary chat"]');
+
+    if (!button) {
+      return false;
+    }
+
+    return button.classList.contains('temp-chat-on') || isTemporaryChatControlActive(button);
+  }
+
+  function isTemporaryChatAlreadyEnabled(provider, control = null) {
+    const currentUrl = new URL(window.location.href);
+
+    switch (provider) {
+      case 'chatgpt':
+        return currentUrl.searchParams.get('temporary-chat') === 'true';
+      case 'claude':
+        return currentUrl.searchParams.has('incognito');
+      case 'grok':
+        return currentUrl.hash === '#private' || isTemporaryChatControlActive(control);
+      case 'gemini': {
+        return isGeminiTemporaryChatEnabled(control);
+      }
+      default:
+        return false;
+    }
+  }
+
   async function enableTemporaryChat(provider) {
     const selectors = TEMP_CHAT_BUTTON_SELECTORS[provider];
     if (!selectors || selectors.length === 0) {
@@ -932,9 +1004,19 @@
       return false;
     }
 
+    if (isTemporaryChatAlreadyEnabled(provider)) {
+      postTemporaryChatEnabled(provider);
+      return true;
+    }
+
     const deadline = Date.now() + TEMP_CHAT_POLL_TIMEOUT_MS;
     while (Date.now() <= deadline) {
       const button = findDeepFirstVisibleElement(selectors) || findFirstVisibleElement(selectors);
+      if (isTemporaryChatAlreadyEnabled(provider, button)) {
+        postTemporaryChatEnabled(provider);
+        return true;
+      }
+
       if (button && isElementEnabled(button)) {
         button.click();
         postTemporaryChatEnabled(provider);
@@ -962,17 +1044,11 @@
     }
 
     // Try to find and click button
-    for (const selector of selectors) {
-      try {
-        const button = document.querySelector(selector);
-        if (button) {
-          console.log('[Text Injection] Clicking new chat button:', selector);
-          button.click();
-          return true;
-        }
-      } catch (error) {
-        console.warn('[Text Injection] Error finding new chat button with selector:', selector, error);
-      }
+    const button = findDeepFirstVisibleElement(selectors) || findFirstVisibleElement(selectors);
+    if (button) {
+      console.log('[Text Injection] Clicking new chat button via visible selector match');
+      button.click();
+      return true;
     }
 
     // Fallback: Try to find any link or button containing "new" text
@@ -984,10 +1060,12 @@
         const href = elem.getAttribute('href') || '';
 
         if (text.includes('new chat') ||
-            text.includes('start new') ||
-            ariaLabel.includes('new chat') ||
-            ariaLabel.includes('start new') ||
-            (href === '/' && elem.closest('nav, aside'))) {
+          text.includes('start new') ||
+          text.includes('新建会话') ||
+          ariaLabel.includes('new chat') ||
+          ariaLabel.includes('start new') ||
+          ariaLabel.includes('新建会话') ||
+          (href === '/' && elem.closest('nav, aside'))) {
           console.log('[Text Injection] Found new chat button by text search');
           elem.click();
           return true;

--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -46,6 +46,7 @@ let sendFocusHardTimeoutIds = new Map();
 let tempChatRetryTimerIds = new Map();
 let tempChatCleanupTimerId = null;
 let tempChatPendingPanelIds = new Set();
+let tempChatButtonRestoreTimerId = null;
 let isTemporaryChatModeEnabled = false;
 let currentGoogleProviderMode = DEFAULT_GOOGLE_PROVIDER_MODE;
 
@@ -71,6 +72,7 @@ const PANELIZE_TEMP_CHAT_ENABLED = 'PANELIZE_TEMP_CHAT_ENABLED';
 const TEMP_CHAT_RETRY_DELAYS = [1200, 2500, 4000];
 const TEMP_CHAT_OPERATION_TIMEOUT_MS = 5000;
 const TEMP_CHAT_SUPPORTED_PROVIDERS = new Set(['chatgpt', 'gemini', 'claude', 'grok']);
+const TEMP_CHAT_RETRY_PROVIDERS = new Set(['gemini', 'grok']);
 const TEMP_CHAT_URLS = {
   chatgpt: 'https://chatgpt.com/?temporary-chat=true',
   claude: 'https://claude.ai/new?incognito',
@@ -171,6 +173,10 @@ function isChatgptProvider(providerId) {
 
 function isTemporaryChatSupportedProvider(providerId) {
   return TEMP_CHAT_SUPPORTED_PROVIDERS.has(providerId);
+}
+
+function requiresTemporaryChatActivationRetry(providerId) {
+  return TEMP_CHAT_RETRY_PROVIDERS.has(providerId);
 }
 
 function isUrlDrivenTemporaryChatProvider(providerId) {
@@ -445,6 +451,21 @@ function setTemporaryChatModeEnabled(enabled) {
   updateTemporaryChatButtonState();
 }
 
+function clearTemporaryChatButtonRestoreTimer() {
+  if (typeof tempChatButtonRestoreTimerId === 'number') {
+    clearTimeout(tempChatButtonRestoreTimerId);
+  }
+  tempChatButtonRestoreTimerId = null;
+}
+
+function scheduleTemporaryChatButtonRestore(delay = 1000) {
+  clearTemporaryChatButtonRestoreTimer();
+  tempChatButtonRestoreTimerId = setTimeout(() => {
+    tempChatButtonRestoreTimerId = null;
+    setTemporaryChatButtonDisabled(false);
+  }, delay);
+}
+
 function clearTemporaryChatRetriesForPanel(panelId) {
   const timerIds = tempChatRetryTimerIds.get(panelId) || [];
   timerIds.forEach(timerId => clearTimeout(timerId));
@@ -457,6 +478,7 @@ function cancelTemporaryChatActivation({ restoreButton = true } = {}) {
   });
   tempChatRetryTimerIds.clear();
   tempChatPendingPanelIds.clear();
+  clearTemporaryChatButtonRestoreTimer();
 
   if (typeof tempChatCleanupTimerId === 'number') {
     clearTimeout(tempChatCleanupTimerId);
@@ -469,13 +491,54 @@ function cancelTemporaryChatActivation({ restoreButton = true } = {}) {
 }
 
 function startTemporaryChatActivationForPanel(panel) {
-  if (!panel || panel.providerId !== 'gemini' || !panel.iframe || !panel.iframe.contentWindow) {
+  if (!panel || !requiresTemporaryChatActivationRetry(panel.providerId) || !panel.iframe || !panel.iframe.contentWindow) {
     return;
   }
 
   clearTemporaryChatRetriesForPanel(panel.id);
   tempChatPendingPanelIds.add(panel.id);
   TEMP_CHAT_RETRY_DELAYS.forEach(delay => scheduleTemporaryChatRetry(panel, delay));
+}
+
+function startTemporaryChatActivationCycle() {
+  cancelTemporaryChatActivation({ restoreButton: false });
+  setTemporaryChatButtonDisabled(true);
+  scheduleTemporaryChatButtonRestore();
+  tempChatCleanupTimerId = setTimeout(() => {
+    cancelTemporaryChatActivation();
+  }, TEMP_CHAT_OPERATION_TIMEOUT_MS);
+}
+
+function startFreshChatForPanel(panel, options = {}) {
+  const preferInPageNewChat = options.preferInPageNewChat === true;
+
+  if (!panel) {
+    return;
+  }
+
+  if (!isTemporaryChatModeEnabled) {
+    postNewChatToPanel(panel);
+    return;
+  }
+
+  if (requiresTemporaryChatActivationRetry(panel.providerId) && !isUrlDrivenTemporaryChatProvider(panel.providerId)) {
+    postNewChatToPanel(panel);
+    startTemporaryChatActivationForPanel(panel);
+    return;
+  }
+
+  if (panel.providerId === 'grok' && preferInPageNewChat) {
+    postNewChatToPanel(panel);
+    startTemporaryChatActivationForPanel(panel);
+    return;
+  }
+
+  if (isUrlDrivenTemporaryChatProvider(panel.providerId)) {
+    reloadPanelIframe(panel, getTemporaryChatUrl(panel.providerId));
+    return;
+  }
+
+  postNewChatToPanel(panel);
 }
 
 function isUnifiedInputOrNewChatControl(target) {
@@ -1104,7 +1167,7 @@ async function addPanel(providerId) {
   iframe.addEventListener('load', () => {
     loadingEl.classList.add('hidden');
     const panel = panels.find(p => p.id === panelId);
-    if (isTemporaryChatModeEnabled && panel && panel.providerId === 'gemini') {
+    if (isTemporaryChatModeEnabled && panel && requiresTemporaryChatActivationRetry(panel.providerId)) {
       startTemporaryChatActivationForPanel(panel);
     }
     setTimeout(() => {
@@ -1399,12 +1462,6 @@ async function sendToPanel(panel, text, images = [], autoSubmit = true, requestI
   });
 }
 
-function postNewChatToAllPanels() {
-  panels.forEach(panel => {
-    postNewChatToPanel(panel);
-  });
-}
-
 // Clear all input boxes (unified input + all panels)
 async function clearAllInputs() {
   // Clear unified input
@@ -1524,22 +1581,12 @@ async function newChatAllProviders() {
   newChatBtn.disabled = true;
 
   if (isTemporaryChatModeEnabled) {
-    cancelTemporaryChatActivation({ restoreButton: false });
-    setTemporaryChatModeEnabled(false);
-
-    panels.forEach(panel => {
-      if (isTemporaryChatSupportedProvider(panel.providerId)) {
-        reloadPanelIframe(panel, getTemporaryChatNormalUrl(panel.providerId));
-        return;
-      }
-
-      postNewChatToPanel(panel);
-    });
-
-    setTemporaryChatButtonDisabled(false);
-  } else {
-    postNewChatToAllPanels();
+    startTemporaryChatActivationCycle();
   }
+
+  panels.forEach(panel => {
+    startFreshChatForPanel(panel, { preferInPageNewChat: true });
+  });
 
   restoreUnifiedInputFocusAfterNewChat();
   showToast('New chat created for all AIs');
@@ -1587,36 +1634,18 @@ async function temporaryChatAllProviders() {
     restoreUnifiedInputFocusAfterNewChat();
     showToast('Temporary chat disabled');
 
-    setTimeout(() => {
-      setTemporaryChatButtonDisabled(false);
-    }, 1000);
+    scheduleTemporaryChatButtonRestore();
     return;
   }
 
-  cancelTemporaryChatActivation({ restoreButton: false });
   setTemporaryChatModeEnabled(true);
-  setTemporaryChatButtonDisabled(true);
+  startTemporaryChatActivationCycle();
 
   panels.forEach(panel => {
-    if (panel.providerId === 'gemini') {
-      postNewChatToPanel(panel);
-      startTemporaryChatActivationForPanel(panel);
-      return;
-    }
-
-    if (isUrlDrivenTemporaryChatProvider(panel.providerId)) {
-      reloadPanelIframe(panel, getTemporaryChatUrl(panel.providerId));
-      return;
-    }
-
-    postNewChatToPanel(panel);
+    startFreshChatForPanel(panel);
   });
 
   restoreUnifiedInputFocusAfterNewChat();
-
-  tempChatCleanupTimerId = setTimeout(() => {
-    cancelTemporaryChatActivation();
-  }, TEMP_CHAT_OPERATION_TIMEOUT_MS);
 
   showToast('Temporary chat enabled where supported');
 }

--- a/tests/e2e/temporary-chat.e2e.test.js
+++ b/tests/e2e/temporary-chat.e2e.test.js
@@ -136,7 +136,7 @@ test.describe('Temporary Chat E2E', () => {
     expect(disableMessages).toHaveLength(0);
   });
 
-  test('new chat disables temporary mode when it is active', async () => {
+  test('new chat keeps temporary mode active for Gemini', async () => {
     await page.evaluate(async () => {
       window.setControlledIframeProvider('gemini');
       await window.addControlledIframe();
@@ -146,15 +146,99 @@ test.describe('Temporary Chat E2E', () => {
     await page.click('#temporary-chat-btn');
     await page.waitForTimeout(5200);
     await page.click('#new-chat-btn');
-    await page.waitForTimeout(200);
+    await page.waitForTimeout(5200);
 
     const debugState = await page.evaluate(() => window.getTemporaryChatDebugState());
     const disableMessages = debugState.messageLog.filter(entry => entry.type === 'DISABLE_TEMP_CHAT');
+    const newChatMessages = debugState.messageLog.filter(entry => entry.type === 'NEW_CHAT');
+    const enableMessages = debugState.messageLog.filter(entry => entry.type === 'ENABLE_TEMP_CHAT');
 
-    expect(debugState.isTemporaryChatModeEnabled).toBe(false);
-    expect(debugState.temporaryChatButtonActive).toBe(false);
-    expect(disableMessages).toEqual([
-      expect.objectContaining({ providerId: 'gemini', source: 'new-chat' })
+    expect(debugState.isTemporaryChatModeEnabled).toBe(true);
+    expect(debugState.temporaryChatButtonActive).toBe(true);
+    expect(debugState.temporaryChatButtonDisabled).toBe(false);
+    expect(disableMessages).toHaveLength(0);
+    expect(newChatMessages).toHaveLength(2);
+    expect(enableMessages).toHaveLength(2);
+  });
+
+  test('new chat keeps URL-driven providers on temporary chat URLs', async () => {
+    await page.evaluate(async () => {
+      window.setControlledIframeProvider('chatgpt');
+      await window.addControlledIframe();
+      window.setTempChatSuccessTimeline([]);
+    });
+
+    await page.click('#temporary-chat-btn');
+    await page.waitForTimeout(1200);
+    await page.click('#new-chat-btn');
+    await page.waitForTimeout(1200);
+
+    const debugState = await page.evaluate(() => window.getTemporaryChatDebugState());
+    const disableMessages = debugState.messageLog.filter(entry => entry.type === 'DISABLE_TEMP_CHAT');
+    const reloadMessages = debugState.messageLog.filter(entry => entry.type === 'RELOAD');
+
+    expect(debugState.isTemporaryChatModeEnabled).toBe(true);
+    expect(debugState.temporaryChatButtonActive).toBe(true);
+    expect(debugState.controlledPanelUrl).toBe('https://chatgpt.com/?temporary-chat=true');
+    expect(disableMessages).toHaveLength(0);
+    expect(reloadMessages).toEqual([
+      expect.objectContaining({ providerId: 'chatgpt', url: 'https://chatgpt.com/?temporary-chat=true' }),
+      expect.objectContaining({ providerId: 'chatgpt', url: 'https://chatgpt.com/?temporary-chat=true' })
     ]);
+  });
+
+  test('new chat re-activates Grok private mode after reload', async () => {
+    await page.evaluate(async () => {
+      window.setControlledIframeProvider('grok');
+      await window.addControlledIframe();
+      window.setTempChatSuccessTimeline([1200]);
+    });
+
+    await page.click('#temporary-chat-btn');
+    await page.waitForTimeout(5200);
+    await page.click('#new-chat-btn');
+    await page.waitForTimeout(5200);
+
+    const debugState = await page.evaluate(() => window.getTemporaryChatDebugState());
+    const disableMessages = debugState.messageLog.filter(entry => entry.type === 'DISABLE_TEMP_CHAT');
+    const reloadMessages = debugState.messageLog.filter(entry => entry.type === 'RELOAD');
+    const enableMessages = debugState.messageLog.filter(entry => entry.type === 'ENABLE_TEMP_CHAT');
+    const newChatMessages = debugState.messageLog.filter(entry => entry.type === 'NEW_CHAT');
+
+    expect(debugState.isTemporaryChatModeEnabled).toBe(true);
+    expect(debugState.temporaryChatButtonActive).toBe(true);
+    expect(debugState.controlledPanelUrl).toBe('https://grok.com/c#private');
+    expect(disableMessages).toHaveLength(0);
+    expect(reloadMessages).toEqual([
+      expect.objectContaining({ providerId: 'grok', url: 'https://grok.com/c#private' })
+    ]);
+    expect(newChatMessages).toEqual([
+      expect.objectContaining({ providerId: 'grok' })
+    ]);
+    expect(enableMessages).toHaveLength(2);
+  });
+
+  test('double new chat cancels previous Gemini retries and restarts a fresh cycle', async () => {
+    await page.evaluate(async () => {
+      window.setControlledIframeProvider('gemini');
+      await window.addControlledIframe();
+      window.setTempChatSuccessTimeline([]);
+    });
+
+    await page.click('#temporary-chat-btn');
+    await page.waitForTimeout(100);
+    await page.click('#new-chat-btn');
+    await page.waitForTimeout(100);
+    await page.click('#new-chat-btn');
+    await page.waitForTimeout(4300);
+
+    const debugState = await page.evaluate(() => window.getTemporaryChatDebugState());
+    const enableMessages = debugState.messageLog.filter(entry => entry.type === 'ENABLE_TEMP_CHAT');
+    const cycleIds = [...new Set(enableMessages.map(entry => entry.cycleId))];
+
+    expect(debugState.isTemporaryChatModeEnabled).toBe(true);
+    expect(debugState.activeTempChatCycleId).toBe(3);
+    expect(enableMessages.map(entry => entry.delay)).toEqual([1200, 2500, 4000]);
+    expect(cycleIds).toEqual([3]);
   });
 });

--- a/tests/e2e/test-temporary-chat.html
+++ b/tests/e2e/test-temporary-chat.html
@@ -29,16 +29,32 @@
     const TEMP_CHAT_RETRY_DELAYS = [1200, 2500, 4000];
     const TEMP_CHAT_OPERATION_TIMEOUT_MS = 5000;
     const TEMP_CHAT_SUPPORTED_PROVIDERS = new Set(['chatgpt', 'gemini', 'claude', 'grok']);
+    const TEMP_CHAT_RETRY_PROVIDERS = new Set(['gemini', 'grok']);
+    const TEMP_CHAT_URLS = {
+      chatgpt: 'https://chatgpt.com/?temporary-chat=true',
+      claude: 'https://claude.ai/new?incognito',
+      grok: 'https://grok.com/c#private'
+    };
+    const TEMP_CHAT_NORMAL_URLS = {
+      chatgpt: 'https://chatgpt.com/',
+      claude: 'https://claude.ai/new',
+      gemini: 'https://gemini.google.com/',
+      grok: 'https://grok.com/'
+    };
 
     let newChatFocusRestoreTimerIds = [];
     let isRestoringFocusAfterNewChat = false;
     let tempChatRetryTimerIds = new Map();
     let tempChatCleanupTimerId = null;
+    let tempChatButtonRestoreTimerId = null;
     let tempChatPendingPanelIds = new Set();
     let isTemporaryChatModeEnabled = false;
     let controlledIframeProviderId = 'chatgpt';
     let tempChatSuccessTimeline = [];
     let tempChatMessageLog = [];
+    let tempChatCycleCounter = 0;
+    let activeTempChatCycleId = 0;
+    let controlledPanelUrl = TEMP_CHAT_NORMAL_URLS.chatgpt;
 
     function focusUnifiedInput(options = {}) {
       const force = Boolean(options.force);
@@ -88,6 +104,22 @@
       return TEMP_CHAT_SUPPORTED_PROVIDERS.has(providerId);
     }
 
+    function requiresTemporaryChatActivationRetry(providerId) {
+      return TEMP_CHAT_RETRY_PROVIDERS.has(providerId);
+    }
+
+    function isUrlDrivenTemporaryChatProvider(providerId) {
+      return Object.prototype.hasOwnProperty.call(TEMP_CHAT_URLS, providerId);
+    }
+
+    function getTemporaryChatUrl(providerId) {
+      return TEMP_CHAT_URLS[providerId] || null;
+    }
+
+    function getTemporaryChatNormalUrl(providerId) {
+      return TEMP_CHAT_NORMAL_URLS[providerId] || 'https://example.com/';
+    }
+
     function getControlledIframePanel() {
       const iframe = document.querySelector('#iframe-container iframe');
       if (!iframe || !iframe.contentWindow) {
@@ -110,24 +142,58 @@
       tempChatMessageLog.push({ type: 'NEW_CHAT', providerId: panel.providerId });
     }
 
+    function reloadPanelIframe(panel, url) {
+      if (!panel) {
+        return;
+      }
+
+      controlledPanelUrl = url;
+      tempChatMessageLog.push({ type: 'RELOAD', providerId: panel.providerId, url });
+
+      if (isTemporaryChatModeEnabled && requiresTemporaryChatActivationRetry(panel.providerId)) {
+        setTimeout(() => {
+          startTemporaryChatActivationForPanel(getControlledIframePanel());
+        }, 0);
+      }
+    }
+
+    function clearTemporaryChatButtonRestoreTimer() {
+      if (typeof tempChatButtonRestoreTimerId === 'number') {
+        clearTimeout(tempChatButtonRestoreTimerId);
+      }
+      tempChatButtonRestoreTimerId = null;
+    }
+
+    function scheduleTemporaryChatButtonRestore(delay = 1000) {
+      clearTemporaryChatButtonRestoreTimer();
+      tempChatButtonRestoreTimerId = setTimeout(() => {
+        tempChatButtonRestoreTimerId = null;
+        temporaryChatBtn.disabled = false;
+      }, delay);
+    }
+
     function clearTemporaryChatRetriesForPanel(panelId) {
       const timerIds = tempChatRetryTimerIds.get(panelId) || [];
       timerIds.forEach(timerId => clearTimeout(timerId));
       tempChatRetryTimerIds.delete(panelId);
     }
 
-    function cancelTemporaryChatActivation() {
+    function cancelTemporaryChatActivation({ restoreButton = true } = {}) {
       tempChatRetryTimerIds.forEach(timerIds => {
         timerIds.forEach(timerId => clearTimeout(timerId));
       });
       tempChatRetryTimerIds.clear();
       tempChatPendingPanelIds.clear();
+      clearTemporaryChatButtonRestoreTimer();
 
       if (typeof tempChatCleanupTimerId === 'number') {
         clearTimeout(tempChatCleanupTimerId);
       }
       tempChatCleanupTimerId = null;
-      temporaryChatBtn.disabled = false;
+
+      if (restoreButton) {
+        temporaryChatBtn.disabled = false;
+      }
     }
 
     function updateTemporaryChatButtonState() {
@@ -140,18 +206,15 @@
       updateTemporaryChatButtonState();
     }
 
-    function postNewChatToAllPanels() {
-      postNewChatToPanel();
-    }
-
     function scheduleTemporaryChatRetry(panel, delay) {
+      const cycleId = activeTempChatCycleId;
       const timerId = setTimeout(() => {
         if (!tempChatPendingPanelIds.has(panel.id)) {
           return;
         }
 
         focusUnifiedInput({ force: true });
-        tempChatMessageLog.push({ type: 'ENABLE_TEMP_CHAT', providerId: panel.providerId, delay });
+        tempChatMessageLog.push({ type: 'ENABLE_TEMP_CHAT', providerId: panel.providerId, delay, cycleId });
       }, delay);
 
       const timerIds = tempChatRetryTimerIds.get(panel.id) || [];
@@ -189,9 +252,63 @@
       });
     }
 
+    function startTemporaryChatActivationForPanel(panel) {
+      if (!panel || !requiresTemporaryChatActivationRetry(panel.providerId)) {
+        return;
+      }
+
+      clearTemporaryChatRetriesForPanel(panel.id);
+      tempChatPendingPanelIds.add(panel.id);
+      TEMP_CHAT_RETRY_DELAYS.forEach(delay => scheduleTemporaryChatRetry(panel, delay));
+      scheduleTempChatSuccessTimeline();
+    }
+
+    function startTemporaryChatActivationCycle() {
+      cancelTemporaryChatActivation({ restoreButton: false });
+      tempChatCycleCounter += 1;
+      activeTempChatCycleId = tempChatCycleCounter;
+      temporaryChatBtn.disabled = true;
+      scheduleTemporaryChatButtonRestore();
+      tempChatCleanupTimerId = setTimeout(() => {
+        cancelTemporaryChatActivation();
+      }, TEMP_CHAT_OPERATION_TIMEOUT_MS);
+    }
+
+    function startFreshChatForPanel(panel, options = {}) {
+      const preferInPageNewChat = options.preferInPageNewChat === true;
+
+      if (!panel) {
+        return;
+      }
+
+      if (!isTemporaryChatModeEnabled) {
+        postNewChatToPanel();
+        return;
+      }
+
+      if (requiresTemporaryChatActivationRetry(panel.providerId) && !isUrlDrivenTemporaryChatProvider(panel.providerId)) {
+        postNewChatToPanel();
+        startTemporaryChatActivationForPanel(panel);
+        return;
+      }
+
+      if (panel.providerId === 'grok' && preferInPageNewChat) {
+        postNewChatToPanel();
+        startTemporaryChatActivationForPanel(panel);
+        return;
+      }
+
+      if (isUrlDrivenTemporaryChatProvider(panel.providerId)) {
+        reloadPanelIframe(panel, getTemporaryChatUrl(panel.providerId));
+        return;
+      }
+
+      postNewChatToPanel();
+    }
+
     function temporaryChatAllProviders() {
       if (isTemporaryChatModeEnabled) {
-        cancelTemporaryChatActivation();
+        cancelTemporaryChatActivation({ restoreButton: false });
         setTemporaryChatModeEnabled(false);
         temporaryChatBtn.disabled = true;
         const panel = getControlledIframePanel();
@@ -201,39 +318,22 @@
           postNewChatToPanel();
         }
         restoreUnifiedInputFocusAfterNewChat();
-        setTimeout(() => {
-          temporaryChatBtn.disabled = false;
-        }, 1000);
+        scheduleTemporaryChatButtonRestore();
         return;
       }
 
-      cancelTemporaryChatActivation();
       setTemporaryChatModeEnabled(true);
-      temporaryChatBtn.disabled = true;
-      postNewChatToAllPanels();
+      startTemporaryChatActivationCycle();
+      startFreshChatForPanel(getControlledIframePanel());
       restoreUnifiedInputFocusAfterNewChat();
-
-      const panel = getControlledIframePanel();
-      if (panel && isTemporaryChatSupportedProvider(panel.providerId)) {
-        tempChatPendingPanelIds.add(panel.id);
-        TEMP_CHAT_RETRY_DELAYS.forEach(delay => scheduleTemporaryChatRetry(panel, delay));
-        scheduleTempChatSuccessTimeline();
-      }
-
-      tempChatCleanupTimerId = setTimeout(() => {
-        cancelTemporaryChatActivation();
-      }, TEMP_CHAT_OPERATION_TIMEOUT_MS);
     }
 
     function newChatAllProviders() {
       if (isTemporaryChatModeEnabled) {
-        cancelTemporaryChatActivation();
-        setTemporaryChatModeEnabled(false);
-        disableTemporaryChatForSupportedPanels('new-chat');
-      } else {
-        postNewChatToAllPanels();
+        startTemporaryChatActivationCycle();
       }
 
+      startFreshChatForPanel(getControlledIframePanel(), { preferInPageNewChat: true });
       restoreUnifiedInputFocusAfterNewChat();
     }
 
@@ -281,6 +381,7 @@
 
     window.setControlledIframeProvider = function(providerId) {
       controlledIframeProviderId = providerId || 'chatgpt';
+      controlledPanelUrl = getTemporaryChatNormalUrl(controlledIframeProviderId);
     };
 
     window.setTempChatSuccessTimeline = function(delays) {
@@ -297,6 +398,8 @@
         pendingPanelCount: tempChatPendingPanelIds.size,
         temporaryChatButtonDisabled: temporaryChatBtn.disabled,
         temporaryChatButtonActive: temporaryChatBtn.classList.contains('active'),
+        activeTempChatCycleId,
+        controlledPanelUrl,
         messageLog: tempChatMessageLog.slice()
       };
     };

--- a/tests/temporary-chat-content-script.test.js
+++ b/tests/temporary-chat-content-script.test.js
@@ -20,6 +20,37 @@ function markVisible(element) {
     configurable: true,
     get: () => document.body,
   });
+
+  element.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    width: 32,
+    height: 32,
+    top: 0,
+    left: 0,
+    right: 32,
+    bottom: 32,
+    toJSON() {
+      return this;
+    }
+  });
+}
+
+function markVisibleAt(element, rect) {
+  markVisible(element);
+  element.getBoundingClientRect = () => ({
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+    top: rect.y,
+    left: rect.x,
+    right: rect.x + rect.width,
+    bottom: rect.y + rect.height,
+    toJSON() {
+      return this;
+    }
+  });
 }
 
 function getTemporaryChatEnabledCalls(postMessageSpy) {
@@ -82,6 +113,70 @@ describe('temporary chat content script', () => {
     ]);
   });
 
+  it('does not click Gemini temporary chat when it is already active', async () => {
+    window.happyDOM.setURL('https://gemini.google.com/app');
+    document.body.innerHTML = `
+      <button data-test-id="temp-chat-button" class="mdc-icon-button temp-chat-button temp-chat-on">Temporary chat</button>
+      <div>Temporary chats don't appear in Recent Chats</div>
+      <input aria-label="Ask questions in a temporary chat">
+    `;
+    const button = document.querySelector('button');
+    markVisible(button);
+
+    const clickSpy = vi.fn();
+    button.addEventListener('click', clickSpy);
+
+    dispatchMultiPanelMessage({ type: 'ENABLE_TEMP_CHAT', context: 'multi-panel' });
+    await wait(50);
+
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(getTemporaryChatEnabledCalls(window.parent.postMessage)).toEqual([
+      expect.objectContaining({ provider: 'gemini' })
+    ]);
+  });
+
+  it('treats Gemini temporary chat as active when the control exposes aria-pressed', async () => {
+    window.happyDOM.setURL('https://gemini.google.com/app');
+    document.body.innerHTML = `
+      <button data-test-id="temp-chat-button" aria-pressed="true">Temporary chat</button>
+    `;
+    const button = document.querySelector('button');
+    markVisible(button);
+
+    const clickSpy = vi.fn();
+    button.addEventListener('click', clickSpy);
+
+    dispatchMultiPanelMessage({ type: 'ENABLE_TEMP_CHAT', context: 'multi-panel' });
+    await wait(50);
+
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(getTemporaryChatEnabledCalls(window.parent.postMessage)).toEqual([
+      expect.objectContaining({ provider: 'gemini' })
+    ]);
+  });
+
+  it('still clicks Gemini temporary chat when page text mentions temporary chat but the control is inactive', async () => {
+    window.happyDOM.setURL('https://gemini.google.com/app');
+    document.body.innerHTML = `
+      <button data-test-id="temp-chat-button" class="mdc-icon-button temp-chat-button">Temporary chat</button>
+      <div>Temporary chats don't appear in Recent Chats</div>
+      <input aria-label="Ask questions in a temporary chat">
+    `;
+    const button = document.querySelector('button');
+    markVisible(button);
+
+    const clickSpy = vi.fn();
+    button.addEventListener('click', clickSpy);
+
+    dispatchMultiPanelMessage({ type: 'ENABLE_TEMP_CHAT', context: 'multi-panel' });
+    await wait(50);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(getTemporaryChatEnabledCalls(window.parent.postMessage)).toEqual([
+      expect.objectContaining({ provider: 'gemini' })
+    ]);
+  });
+
   it('enables incognito for Claude', async () => {
     window.happyDOM.setURL('https://claude.ai/new');
     document.body.innerHTML = '<button aria-label="Use incognito">Incognito</button>';
@@ -116,6 +211,63 @@ describe('temporary chat content script', () => {
     expect(getTemporaryChatEnabledCalls(window.parent.postMessage)).toEqual([
       expect.objectContaining({ provider: 'grok' })
     ]);
+  });
+
+  it('does not click Grok private chat when it is already active', async () => {
+    window.happyDOM.setURL('https://grok.com/c#private');
+    document.body.innerHTML = '<a href="/c#private" aria-label="Switch to Private Chat">Private</a>';
+    const link = document.querySelector('a');
+    markVisible(link);
+
+    const clickSpy = vi.fn((event) => event.preventDefault());
+    link.addEventListener('click', clickSpy);
+
+    dispatchMultiPanelMessage({ type: 'ENABLE_TEMP_CHAT', context: 'multi-panel' });
+    await wait(50);
+
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(getTemporaryChatEnabledCalls(window.parent.postMessage)).toEqual([
+      expect.objectContaining({ provider: 'grok' })
+    ]);
+  });
+
+  it('prefers the in-viewport Grok new chat control over offscreen links', async () => {
+    window.happyDOM.setURL('https://grok.com/c#private');
+    document.body.innerHTML = `
+      <a id="hidden-home" href="/" aria-label="Home page">Home</a>
+      <a id="visible-compose" href="/">Compose</a>
+    `;
+
+    const hiddenHome = document.getElementById('hidden-home');
+    const visibleCompose = document.getElementById('visible-compose');
+    markVisibleAt(hiddenHome, { x: -246, y: 10, width: 36, height: 36 });
+    markVisibleAt(visibleCompose, { x: 378, y: 12, width: 40, height: 40 });
+
+    const hiddenSpy = vi.fn((event) => event.preventDefault());
+    const visibleSpy = vi.fn((event) => event.preventDefault());
+    hiddenHome.addEventListener('click', hiddenSpy);
+    visibleCompose.addEventListener('click', visibleSpy);
+
+    dispatchMultiPanelMessage({ type: 'NEW_CHAT', context: 'multi-panel' });
+    await wait(50);
+
+    expect(hiddenSpy).not.toHaveBeenCalled();
+    expect(visibleSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to Kimi Chinese new chat text without invalid CSS selectors', async () => {
+    window.happyDOM.setURL('https://www.kimi.com/');
+    document.body.innerHTML = '<button id="kimi-new-chat">新建会话</button>';
+    const button = document.getElementById('kimi-new-chat');
+    markVisible(button);
+
+    const clickSpy = vi.fn();
+    button.addEventListener('click', clickSpy);
+
+    dispatchMultiPanelMessage({ type: 'NEW_CHAT', context: 'multi-panel' });
+    await wait(50);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 
   it('silently skips unsupported providers', async () => {


### PR DESCRIPTION
## Summary
- keep temporary chat mode enabled when using New Chat for All instead of treating it as a disable action
- restart provider-specific temporary chat activation for Gemini and Grok while reloading URL-driven providers into their temporary routes
- harden content-script new chat/temp chat detection and expand unit and e2e coverage for repeated activation flows

## Testing
- npm test -- tests/temporary-chat-content-script.test.js
- npx playwright test tests/e2e/temporary-chat.e2e.test.js