### PR TITLE
Automate release preparation workflow

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,88 @@
+name: Release Prep
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Target version (x.y.z)'
+        required: true
+        type: string
+      changelog:
+        description: 'Release bullets separated with literal \n sequences'
+        required: true
+        type: string
+      base_ref:
+        description: 'Base branch or ref to prepare the release from'
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-prep-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  release-prep:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
+      RELEASE_CHANGELOG: ${{ inputs.changelog }}
+      RELEASE_BASE_REF: ${{ inputs.base_ref }}
+
+    steps:
+      - name: Checkout base ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_ref }}
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Ensure release branch does not already exist remotely
+        run: |
+          if git ls-remote --exit-code --heads origin "release/${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "Remote branch release/${RELEASE_VERSION} already exists"
+            exit 1
+          fi
+
+      - name: Prepare release files
+        run: npm run release:prepare
+
+      - name: Run unit tests
+        run: npx vitest run --exclude='tests/e2e/**'
+
+      - name: Build release packages
+        run: npm run release:package
+
+      - name: Upload release zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: panelize-${{ inputs.version }}-release
+          path: dist/release-${{ inputs.version }}/panelize-${{ inputs.version }}-release.zip
+          retention-days: 14
+
+      - name: Upload cws zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: panelize-${{ inputs.version }}-cws
+          path: dist/release-${{ inputs.version }}/panelize-${{ inputs.version }}-cws.zip
+          retention-days: 14
+
+      - name: Commit and push release branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "release/${RELEASE_VERSION}"
+          git add manifest.json package.json package-lock.json data/version-info.json CHANGELOG.md
+          git commit -m "chore: bump version to ${RELEASE_VERSION}"
+          git push origin "release/${RELEASE_VERSION}"

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,6 @@ CLAUDE.md
 specs/
 .codex/
 AGENTS.md
-scripts/
 web-ext-artifacts/
 
 # Documentation (local reference only)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "type": "module",
   "scripts": {
     "lint": "web-ext lint --source-dir .",
+    "release:package": "node scripts/package-release.js",
+    "release:prepare": "node scripts/prepare-release.js",
+    "release:prepare:dry-run": "node scripts/prepare-release.js --dry-run",
+    "release:prep": "npm run release:prepare && npm run release:package",
     "test": "vitest",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",

--- a/scripts/package-release.js
+++ b/scripts/package-release.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  assertPackageEntries,
+  ensureCommandExists,
+  normalizeZipEntries,
+  PACKAGE_EXCLUDED_PREFIXES,
+  PACKAGE_INCLUDE_PATHS,
+  resolveCliOptions
+} from './release-utils.js';
+
+async function main() {
+  const repoRoot = process.cwd();
+  const options = resolveCliOptions();
+  const manifestPath = path.join(repoRoot, 'manifest.json');
+  const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+  const version = options.version || manifest.version;
+
+  if (options.version && options.version !== manifest.version) {
+    throw new Error(
+      `Requested package version ${options.version} does not match manifest version ${manifest.version}`
+    );
+  }
+
+  ensureCommandExists('zip');
+  ensureCommandExists('unzip');
+
+  const outputDir = path.join(repoRoot, 'dist', `release-${version}`);
+  const releaseZipPath = path.join(outputDir, `panelize-${version}-release.zip`);
+  const cwsZipPath = path.join(outputDir, `panelize-${version}-cws.zip`);
+  const stagingDir = path.join(outputDir, 'staging');
+
+  await fs.rm(outputDir, { recursive: true, force: true });
+  await fs.mkdir(stagingDir, { recursive: true });
+
+  for (const relativePath of PACKAGE_INCLUDE_PATHS) {
+    await fs.cp(path.join(repoRoot, relativePath), path.join(stagingDir, relativePath), {
+      recursive: true
+    });
+  }
+
+  for (const excludedPath of PACKAGE_EXCLUDED_PREFIXES) {
+    await fs.rm(path.join(stagingDir, excludedPath), {
+      recursive: true,
+      force: true
+    });
+  }
+
+  execFileSync('zip', ['-r', releaseZipPath, '.', '-x', '*.DS_Store'], {
+    cwd: stagingDir,
+    stdio: 'inherit'
+  });
+
+  await fs.copyFile(releaseZipPath, cwsZipPath);
+
+  const zipEntries = normalizeZipEntries(
+    execFileSync('unzip', ['-Z1', releaseZipPath], {
+      cwd: repoRoot,
+      encoding: 'utf8'
+    })
+  );
+  const packagedManifest = JSON.parse(
+    execFileSync('unzip', ['-p', releaseZipPath, 'manifest.json'], {
+      cwd: repoRoot,
+      encoding: 'utf8'
+    })
+  );
+
+  assertPackageEntries(zipEntries, packagedManifest);
+  await fs.rm(stagingDir, { recursive: true, force: true });
+
+  console.log(`[package-release] Created ${releaseZipPath}`);
+  console.log(`[package-release] Created ${cwsZipPath}`);
+}
+
+main().catch(error => {
+  console.error(`[package-release] ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import {
+  assertChangelogEntries,
+  assertLocalReleaseBranchMissing,
+  assertTargetVersionIsNewer,
+  assertVersionStateConsistency,
+  buildChangelogSection,
+  formatDryRunPlan,
+  getShortHeadCommitHash,
+  getUtcDateStamp,
+  getVersionState,
+  isValidSemver,
+  parseChangelogEntries,
+  prependChangelogSection,
+  readJson,
+  readText,
+  resolveCliOptions,
+  VERSION_FILE_PATHS,
+  writeJson,
+  writeText
+} from './release-utils.js';
+
+async function main() {
+  const repoRoot = process.cwd();
+  const options = resolveCliOptions();
+
+  if (!options.version) {
+    throw new Error('Missing release version. Provide --version or RELEASE_VERSION');
+  }
+
+  if (!isValidSemver(options.version)) {
+    throw new Error(`Invalid version "${options.version}". Expected x.y.z`);
+  }
+
+  const changelogEntries = parseChangelogEntries(options.changelog);
+  assertChangelogEntries(changelogEntries);
+
+  const versionState = await getVersionState(repoRoot);
+  const currentVersion = assertVersionStateConsistency(versionState);
+  assertTargetVersionIsNewer(currentVersion, options.version);
+  assertLocalReleaseBranchMissing(repoRoot, options.version);
+
+  const buildDate = getUtcDateStamp();
+  const commitHash = getShortHeadCommitHash(repoRoot);
+
+  if (options.dryRun) {
+    console.log(formatDryRunPlan({
+      version: options.version,
+      currentVersion,
+      baseRef: options.baseRef,
+      buildDate,
+      commitHash,
+      changelogEntries
+    }));
+    return;
+  }
+
+  execFileSync('npm', ['version', options.version, '--no-git-tag-version'], {
+    cwd: repoRoot,
+    stdio: 'inherit'
+  });
+
+  const manifest = await readJson(repoRoot, VERSION_FILE_PATHS.manifest);
+  manifest.version = options.version;
+  await writeJson(repoRoot, VERSION_FILE_PATHS.manifest, manifest);
+
+  await writeJson(repoRoot, VERSION_FILE_PATHS.versionInfo, {
+    version: options.version,
+    commitHash,
+    buildDate
+  });
+
+  const currentChangelog = await readText(repoRoot, 'CHANGELOG.md');
+  const newSection = buildChangelogSection(options.version, buildDate, changelogEntries);
+  await writeText(repoRoot, 'CHANGELOG.md', prependChangelogSection(currentChangelog, newSection));
+
+  console.log(`[prepare-release] Updated release metadata for ${options.version}`);
+}
+
+main().catch(error => {
+  console.error(`[prepare-release] ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -1,0 +1,306 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+export const VERSION_FILE_PATHS = {
+  manifest: 'manifest.json',
+  packageJson: 'package.json',
+  packageLock: 'package-lock.json',
+  versionInfo: 'data/version-info.json'
+};
+
+export const BUMP_COMMIT_FILES = [
+  VERSION_FILE_PATHS.manifest,
+  VERSION_FILE_PATHS.packageJson,
+  VERSION_FILE_PATHS.packageLock,
+  VERSION_FILE_PATHS.versionInfo,
+  'CHANGELOG.md'
+];
+
+export const PACKAGE_INCLUDE_PATHS = [
+  '_locales',
+  'background',
+  'content-scripts',
+  'data',
+  'icons',
+  'libs',
+  'modules',
+  'multi-panel',
+  'options',
+  'rules',
+  'LICENSE',
+  'manifest.json'
+];
+
+export const PACKAGE_EXCLUDED_PREFIXES = [
+  'tests/',
+  'dist/',
+  'test-results/',
+  'docs/',
+  'assets/screenshots/',
+  '.github/',
+  'scripts/',
+  '_metadata/',
+  'icons/ICON_GUIDE.md',
+  'data/prompt-libraries/Generate_a_Basic_Prompt_Library.md',
+  'data/prompt-libraries/transform-libraries.js'
+];
+
+function getArgValue(argv, flagName) {
+  const directIndex = argv.indexOf(flagName);
+  if (directIndex >= 0 && argv[directIndex + 1]) {
+    return argv[directIndex + 1];
+  }
+
+  const prefixedArg = argv.find(arg => arg.startsWith(`${flagName}=`));
+  if (prefixedArg) {
+    return prefixedArg.slice(flagName.length + 1);
+  }
+
+  return '';
+}
+
+export function resolveCliOptions(argv = process.argv.slice(2), env = process.env) {
+  return {
+    version: getArgValue(argv, '--version') || env.RELEASE_VERSION || '',
+    changelog: getArgValue(argv, '--changelog') || env.RELEASE_CHANGELOG || '',
+    baseRef: getArgValue(argv, '--base-ref') || env.RELEASE_BASE_REF || 'main',
+    dryRun: argv.includes('--dry-run') || env.RELEASE_DRY_RUN === '1'
+  };
+}
+
+export function isValidSemver(version) {
+  return /^\d+\.\d+\.\d+$/.test(version);
+}
+
+export function compareVersions(current, next) {
+  const currentParts = current.split('.').map(Number);
+  const nextParts = next.split('.').map(Number);
+  const maxLength = Math.max(currentParts.length, nextParts.length);
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const currentPart = currentParts[index] ?? 0;
+    const nextPart = nextParts[index] ?? 0;
+
+    if (currentPart < nextPart) {
+      return -1;
+    }
+
+    if (currentPart > nextPart) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+export function parseChangelogEntries(rawChangelog) {
+  return rawChangelog
+    .replace(/\\n/g, '\n')
+    .split(/\r?\n/)
+    .map(entry => entry.trim())
+    .filter(Boolean)
+    .map(entry => entry.replace(/^-\s*/, '').trim())
+    .filter(Boolean);
+}
+
+export function getUtcDateStamp() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function readJson(repoRoot, relativePath) {
+  const filePath = path.join(repoRoot, relativePath);
+  const fileContent = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(fileContent);
+}
+
+export async function writeJson(repoRoot, relativePath, data) {
+  const filePath = path.join(repoRoot, relativePath);
+  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+export async function readText(repoRoot, relativePath) {
+  return fs.readFile(path.join(repoRoot, relativePath), 'utf8');
+}
+
+export async function writeText(repoRoot, relativePath, content) {
+  await fs.writeFile(path.join(repoRoot, relativePath), content);
+}
+
+export async function getVersionState(repoRoot) {
+  const manifest = await readJson(repoRoot, VERSION_FILE_PATHS.manifest);
+  const packageJson = await readJson(repoRoot, VERSION_FILE_PATHS.packageJson);
+  const packageLock = await readJson(repoRoot, VERSION_FILE_PATHS.packageLock);
+  const versionInfo = await readJson(repoRoot, VERSION_FILE_PATHS.versionInfo);
+
+  return {
+    manifest: manifest.version,
+    packageJson: packageJson.version,
+    packageLock: packageLock.version,
+    packageLockRootPackage: packageLock.packages?.['']?.version ?? '',
+    versionInfo: versionInfo.version
+  };
+}
+
+export function assertVersionStateConsistency(versionState) {
+  const manifestVersion = versionState.manifest;
+  const candidates = [
+    ['manifest.json', versionState.manifest],
+    ['package.json', versionState.packageJson],
+    ['package-lock.json', versionState.packageLock],
+    ['package-lock.json packages[""]', versionState.packageLockRootPackage],
+    ['data/version-info.json', versionState.versionInfo]
+  ];
+
+  const mismatches = candidates.filter(([, version]) => version !== manifestVersion);
+  if (mismatches.length > 0) {
+    const mismatchSummary = mismatches
+      .map(([label, version]) => `${label}: ${version || '<missing>'}`)
+      .join(', ');
+    throw new Error(`Version files are out of sync. Expected ${manifestVersion}. Found ${mismatchSummary}`);
+  }
+
+  return manifestVersion;
+}
+
+export function assertTargetVersionIsNewer(currentVersion, targetVersion) {
+  if (compareVersions(currentVersion, targetVersion) >= 0) {
+    throw new Error(`Target version ${targetVersion} must be greater than current version ${currentVersion}`);
+  }
+}
+
+export function assertChangelogEntries(entries) {
+  if (entries.length === 0) {
+    throw new Error('At least one changelog entry is required');
+  }
+}
+
+export function localBranchExists(repoRoot, branchName) {
+  const result = spawnSync('git', ['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`], {
+    cwd: repoRoot,
+    stdio: 'ignore'
+  });
+
+  return result.status === 0;
+}
+
+export function assertLocalReleaseBranchMissing(repoRoot, version) {
+  const branchName = `release/${version}`;
+  if (localBranchExists(repoRoot, branchName)) {
+    throw new Error(`Local branch ${branchName} already exists`);
+  }
+}
+
+export function getShortHeadCommitHash(repoRoot) {
+  return execFileSync('git', ['rev-parse', '--short=7', 'HEAD'], {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  }).trim();
+}
+
+export function buildChangelogSection(version, buildDate, changelogEntries) {
+  const lines = [
+    `## ${version} - ${buildDate}`,
+    ...changelogEntries.map(entry => `- ${entry}`),
+    '',
+    ''
+  ];
+
+  return lines.join('\n');
+}
+
+export function prependChangelogSection(changelogContent, section) {
+  const heading = '# Changelog';
+  if (!changelogContent.startsWith(heading)) {
+    throw new Error('CHANGELOG.md must start with "# Changelog"');
+  }
+
+  const rest = changelogContent.slice(heading.length).replace(/^\n*/, '');
+  return `${heading}\n\n${section}${rest}`;
+}
+
+export function formatDryRunPlan({
+  version,
+  currentVersion,
+  baseRef,
+  buildDate,
+  commitHash,
+  changelogEntries
+}) {
+  return [
+    `[prepare-release] Dry run for ${version}`,
+    `Base ref: ${baseRef}`,
+    `Current version: ${currentVersion}`,
+    `Next version: ${version}`,
+    `Commit hash: ${commitHash}`,
+    `Build date (UTC): ${buildDate}`,
+    'Files to update:',
+    `- ${VERSION_FILE_PATHS.packageJson} and ${VERSION_FILE_PATHS.packageLock} via npm version`,
+    `- ${VERSION_FILE_PATHS.manifest}`,
+    `- ${VERSION_FILE_PATHS.versionInfo}`,
+    '- CHANGELOG.md',
+    'Planned changelog section:',
+    buildChangelogSection(version, buildDate, changelogEntries).trimEnd()
+  ].join('\n');
+}
+
+export function readManifestReferencedPaths(manifest) {
+  const requiredPaths = new Set();
+
+  if (manifest.background?.service_worker) {
+    requiredPaths.add(manifest.background.service_worker);
+  }
+
+  if (typeof manifest.options_page === 'string' && manifest.options_page.length > 0) {
+    requiredPaths.add(manifest.options_page);
+  }
+
+  if (manifest.options_ui?.page) {
+    requiredPaths.add(manifest.options_ui.page);
+  }
+
+  for (const contentScript of manifest.content_scripts ?? []) {
+    for (const scriptPath of contentScript.js ?? []) {
+      requiredPaths.add(scriptPath);
+    }
+  }
+
+  for (const resourceGroup of manifest.web_accessible_resources ?? []) {
+    for (const resourcePath of resourceGroup.resources ?? []) {
+      requiredPaths.add(resourcePath);
+    }
+  }
+
+  return Array.from(requiredPaths).sort();
+}
+
+export function normalizeZipEntries(rawEntries) {
+  return rawEntries
+    .split(/\r?\n/)
+    .map(entry => entry.trim())
+    .filter(Boolean)
+    .map(entry => entry.replace(/^\.\//, '').replace(/\/$/, ''));
+}
+
+export function assertPackageEntries(entries, manifest) {
+  const entrySet = new Set(entries);
+  const missingPaths = readManifestReferencedPaths(manifest).filter(resourcePath => !entrySet.has(resourcePath));
+  if (missingPaths.length > 0) {
+    throw new Error(`Packaged zip is missing manifest-referenced files: ${missingPaths.join(', ')}`);
+  }
+
+  const forbiddenEntries = entries.filter(entry =>
+    PACKAGE_EXCLUDED_PREFIXES.some(prefix => entry === prefix.replace(/\/$/, '') || entry.startsWith(prefix))
+  );
+
+  if (forbiddenEntries.length > 0) {
+    throw new Error(`Packaged zip contains excluded paths: ${forbiddenEntries.join(', ')}`);
+  }
+}
+
+export function ensureCommandExists(commandName) {
+  const result = spawnSync('which', [commandName], { stdio: 'ignore' });
+  if (result.status !== 0) {
+    throw new Error(`Required command not found: ${commandName}`);
+  }
+}

--- a/tests/release-utils.test.js
+++ b/tests/release-utils.test.js
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertPackageEntries,
+  assertTargetVersionIsNewer,
+  assertVersionStateConsistency,
+  buildChangelogSection,
+  compareVersions,
+  normalizeZipEntries,
+  parseChangelogEntries,
+  prependChangelogSection,
+  readManifestReferencedPaths
+} from '../scripts/release-utils.js';
+
+describe('release utils', () => {
+  it('compares semver values correctly', () => {
+    expect(compareVersions('1.1.0', '1.1.1')).toBe(-1);
+    expect(compareVersions('1.1.1', '1.1.1')).toBe(0);
+    expect(compareVersions('1.2.0', '1.1.9')).toBe(1);
+  });
+
+  it('normalizes changelog entries from literal newline input', () => {
+    expect(parseChangelogEntries('Fixed one\\n- Fixed two\\n\\nAdded three')).toEqual([
+      'Fixed one',
+      'Fixed two',
+      'Added three'
+    ]);
+  });
+
+  it('rejects non-incrementing target versions', () => {
+    expect(() => assertTargetVersionIsNewer('1.1.0', '1.1.0')).toThrow(/must be greater/);
+    expect(() => assertTargetVersionIsNewer('1.1.0', '1.0.9')).toThrow(/must be greater/);
+  });
+
+  it('requires all version files to match the manifest version', () => {
+    expect(() => assertVersionStateConsistency({
+      manifest: '1.1.0',
+      packageJson: '1.1.0',
+      packageLock: '1.1.0',
+      packageLockRootPackage: '1.1.0',
+      versionInfo: '1.1.1'
+    })).toThrow(/out of sync/);
+  });
+
+  it('builds changelog sections in the project format', () => {
+    expect(buildChangelogSection('1.1.1', '2026-04-13', ['Fixed release prep'])).toBe(
+      '## 1.1.1 - 2026-04-13\n- Fixed release prep\n\n'
+    );
+  });
+
+  it('prepends a new changelog section after the title', () => {
+    const original = '# Changelog\n\n## 1.1.0 - 2026-04-07\n- Existing entry\n';
+    const section = '## 1.1.1 - 2026-04-13\n- New entry\n\n';
+
+    expect(prependChangelogSection(original, section)).toBe(
+      '# Changelog\n\n## 1.1.1 - 2026-04-13\n- New entry\n\n## 1.1.0 - 2026-04-07\n- Existing entry\n'
+    );
+  });
+
+  it('requires changelog content to start with the heading', () => {
+    expect(() => prependChangelogSection('## 1.1.0 - 2026-04-07\n- Existing entry\n', 'section'))
+      .toThrow(/must start with "# Changelog"/);
+  });
+
+  it('collects manifest referenced paths for smoke checks', () => {
+    const manifest = {
+      background: { service_worker: 'background/service-worker.js' },
+      options_page: 'options/options.html',
+      content_scripts: [
+        { js: ['content-scripts/a.js', 'content-scripts/b.js'] }
+      ],
+      web_accessible_resources: [
+        { resources: ['data/version-info.json', 'multi-panel/multi-panel.html'] }
+      ]
+    };
+
+    expect(readManifestReferencedPaths(manifest)).toEqual([
+      'background/service-worker.js',
+      'content-scripts/a.js',
+      'content-scripts/b.js',
+      'data/version-info.json',
+      'multi-panel/multi-panel.html',
+      'options/options.html'
+    ]);
+  });
+
+  it('normalizes zip entry output', () => {
+    expect(normalizeZipEntries('manifest.json\ncontent-scripts/\ncontent-scripts/a.js\n')).toEqual([
+      'manifest.json',
+      'content-scripts',
+      'content-scripts/a.js'
+    ]);
+  });
+
+  it('fails smoke checks on missing manifest referenced files', () => {
+    const manifest = {
+      background: { service_worker: 'background/service-worker.js' },
+      content_scripts: [{ js: ['content-scripts/a.js'] }],
+      web_accessible_resources: [{ resources: ['data/version-info.json'] }]
+    };
+
+    expect(() => assertPackageEntries(['manifest.json', 'background/service-worker.js'], manifest))
+      .toThrow(/missing manifest-referenced files/);
+  });
+
+  it('fails smoke checks on excluded packaged paths', () => {
+    const manifest = {
+      background: { service_worker: 'background/service-worker.js' },
+      content_scripts: [],
+      web_accessible_resources: []
+    };
+
+    expect(() => assertPackageEntries([
+      'manifest.json',
+      'background/service-worker.js',
+      'tests/focus.e2e.test.js'
+    ], manifest)).toThrow(/contains excluded paths/);
+  });
+});


### PR DESCRIPTION
## Summary
- stop ignoring the scripts directory so release tooling can be tracked normally
- add local release preparation and packaging scripts with dry-run support and package smoke checks
- add a manual GitHub Actions workflow that prepares a release branch and uploads release artifacts without tagging or publishing

## Testing
- npm test -- tests/release-utils.test.js
- npx vitest run --exclude='tests/e2e/**'
- RELEASE_VERSION=1.1.2 RELEASE_CHANGELOG='Fixed release prep\\n- Added package workflow' RELEASE_BASE_REF=main npm run release:prepare:dry-run
- npm run release:package