### PR TITLE
chore: prepare release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.1 - 2026-04-13
+- Fixed: New Chat for All now preserves temporary chat mode for supported providers.
+- Fixed: Gemini and Grok temporary or private chat activation no longer toggles off when already active.
+- Fixed: Grok private new-chat detection now avoids offscreen controls in narrow layouts.
+
 ## 1.1.0 - 2026-04-07
 - Added: One-click temporary chat toggle for supported providers in multi-panel. (#39)
 - Added: Global Google mode sync with AI/Search mode switching and repeat send/fill fixes. (#37)

--- a/data/version-info.json
+++ b/data/version-info.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
-  "commitHash": "b425f5f",
-  "buildDate": "2026-04-07"
+  "version": "1.1.1",
+  "commitHash": "1f42db6",
+  "buildDate": "2026-04-13"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Panelize",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Compare AI assistants side by side in one window. Send one prompt and review responses faster.",
   "default_locale": "en",
   "permissions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panelize",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panelize",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "devDependencies": {
         "@playwright/test": "^1.58.1",
         "@vitest/ui": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panelize",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Compare AI chatbots side-by-side",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump extension version metadata to 1.1.1
- add the 1.1.1 changelog entry for the temporary chat fixes
- prepare the release branch generated by the Release Prep workflow

## Testing
- Release Prep workflow run: https://github.com/Manho/Panelize/actions/runs/24324411087