### PR TITLE
Fix Doubao release review findings

### DIFF
--- a/content-scripts/text-injection-all-providers.js
+++ b/content-scripts/text-injection-all-providers.js
@@ -1375,11 +1375,18 @@
         startChatgptSendTracking(requestId);
       }
 
+      const imageInjectionResults = [];
+
       // Inject images first
       for (const image of images) {
-        await injectSingleImage(provider, image);
+        imageInjectionResults.push(await injectSingleImage(provider, image));
         // Wait a bit between images
         await sleep(200);
+      }
+
+      const allImagesInjected = imageInjectionResults.every(Boolean);
+      if (!allImagesInjected) {
+        console.warn('[Image Injection] One or more images failed to inject for:', provider);
       }
 
       // Wait for images to upload
@@ -1388,8 +1395,12 @@
       // Then inject text if provided
       if (text && text.trim()) {
         await sleep(300);
-        injectText(provider, text, autoSubmit, providerMode);
+        injectText(provider, text, autoSubmit && allImagesInjected, providerMode);
       } else if (autoSubmit) {
+        if (!allImagesInjected) {
+          console.warn('[Image Injection] Skipping auto-submit because image injection failed for:', provider);
+          return;
+        }
         // If no text but autoSubmit is true, click send button
         await sleep(300);
         clickSendButton(provider, providerMode);
@@ -1618,15 +1629,15 @@
         fileInput.dispatchEvent(new Event('input', { bubbles: true }));
         fileInput.dispatchEvent(new Event('change', { bubbles: true }));
 
-        const uploadAccepted = await waitForDoubaoImagePreview(1200) ||
-          Boolean(fileInput.files && fileInput.files.length > 0);
+        const uploadAccepted = await waitForDoubaoImagePreview(1200);
 
         if (uploadAccepted) {
-          console.log('[Image Injection] Doubao: File input triggered');
+          console.log('[Image Injection] Doubao: Image preview detected');
           return true;
         }
 
-        await sleep(250);
+        console.warn('[Image Injection] Doubao: Upload did not produce an image preview');
+        return false;
       }
 
       console.warn('[Image Injection] Doubao: Upload did not produce a preview after retries');

--- a/modules/provider-defaults.js
+++ b/modules/provider-defaults.js
@@ -23,27 +23,28 @@ export function migrateEnabledProvidersOnUpdate(enabledProviders, providerOrder)
 
   const enabledProvidersAreLegacyDefault =
     nextEnabledProviders === null ||
-    arraysMatchExactly(nextEnabledProviders, LEGACY_DEFAULT_PROVIDER_IDS);
+    arraysContainSameIds(nextEnabledProviders, LEGACY_DEFAULT_PROVIDER_IDS);
 
   if (!enabledProvidersAreLegacyDefault) {
     return null;
   }
 
-  const migratedEnabledProviders = DEFAULT_PROVIDER_IDS;
-  const migratedProviderOrder = buildMigratedProviderOrder(nextProviderOrder);
+  const migratedProviderIds = buildMigratedProviderOrder(nextProviderOrder || nextEnabledProviders);
 
   return {
-    enabledProviders: migratedEnabledProviders,
-    providerOrder: migratedProviderOrder,
+    enabledProviders: migratedProviderIds,
+    providerOrder: migratedProviderIds,
   };
 }
 
-function arraysMatchExactly(left, right) {
+function arraysContainSameIds(left, right) {
   if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
     return false;
   }
 
-  return left.every((value, index) => value === right[index]);
+  const leftIds = new Set(left);
+  const rightIds = new Set(right);
+  return leftIds.size === rightIds.size && left.every((value) => rightIds.has(value));
 }
 
 function buildMigratedProviderOrder(providerOrder) {

--- a/tests/doubao-content-script.test.js
+++ b/tests/doubao-content-script.test.js
@@ -120,6 +120,11 @@ describe('doubao content script integration', () => {
   it('uploads images through the Doubao file input and keeps text injection working', async () => {
     const { editor, fileInput } = createDoubaoComposerDom();
     const changeSpy = vi.fn();
+    fileInput.addEventListener('change', () => {
+      const preview = document.createElement('img');
+      preview.src = 'blob:https://www.doubao.com/test-preview';
+      document.getElementById('input-engine-container').appendChild(preview);
+    });
     fileInput.addEventListener('change', changeSpy);
 
     dispatchMultiPanelMessage({
@@ -141,6 +146,31 @@ describe('doubao content script integration', () => {
     expect(fileInput.files).toHaveLength(1);
     expect(fileInput.files[0].name).toBe('sample.png');
   });
+
+  it('does not auto-submit Doubao images when upload preview never appears', async () => {
+    const { fileInput, sendButton } = createDoubaoComposerDom();
+    const clickSpy = vi.fn();
+    const changeSpy = vi.fn();
+    fileInput.addEventListener('change', changeSpy);
+    sendButton.addEventListener('click', clickSpy);
+
+    dispatchMultiPanelMessage({
+      type: 'INJECT_TEXT_WITH_IMAGES',
+      text: 'text with missing preview',
+      images: [{
+        name: 'sample.png',
+        type: 'image/png',
+        dataUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2Z2ioAAAAASUVORK5CYII='
+      }],
+      autoSubmit: true,
+      context: 'multi-panel',
+    });
+
+    await wait(3500);
+
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+    expect(clickSpy).not.toHaveBeenCalled();
+  }, 6000);
 
   it('uses the visible new chat control for Doubao', () => {
     const { newChatButton } = createDoubaoComposerDom();

--- a/tests/provider-defaults.test.js
+++ b/tests/provider-defaults.test.js
@@ -41,7 +41,19 @@ describe('provider defaults', () => {
     expect(
       migrateEnabledProvidersOnUpdate(LEGACY_DEFAULT_PROVIDER_IDS, ['claude', 'chatgpt', 'gemini'])
     ).toEqual({
-      enabledProviders: DEFAULT_PROVIDER_IDS,
+      enabledProviders: ['claude', 'chatgpt', 'gemini', 'grok', 'deepseek', 'kimi', 'google', 'doubao'],
+      providerOrder: ['claude', 'chatgpt', 'gemini', 'grok', 'deepseek', 'kimi', 'google', 'doubao'],
+    });
+  });
+
+  it('migrates reordered legacy defaults while preserving the user order', () => {
+    expect(
+      migrateEnabledProvidersOnUpdate(
+        ['claude', 'chatgpt', 'gemini', 'grok', 'deepseek', 'kimi', 'google'],
+        null
+      )
+    ).toEqual({
+      enabledProviders: ['claude', 'chatgpt', 'gemini', 'grok', 'deepseek', 'kimi', 'google', 'doubao'],
       providerOrder: ['claude', 'chatgpt', 'gemini', 'grok', 'deepseek', 'kimi', 'google', 'doubao'],
     });
   });
@@ -49,6 +61,15 @@ describe('provider defaults', () => {
   it('does not override customized enabled providers', () => {
     expect(
       migrateEnabledProvidersOnUpdate(['chatgpt', 'claude'], LEGACY_DEFAULT_PROVIDER_IDS)
+    ).toBeNull();
+  });
+
+  it('does not migrate duplicate legacy provider lists that are missing a default provider', () => {
+    expect(
+      migrateEnabledProvidersOnUpdate(
+        ['chatgpt', 'chatgpt', 'claude', 'gemini', 'grok', 'deepseek', 'kimi'],
+        null
+      )
     ).toBeNull();
   });
 });

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -146,7 +146,7 @@ describe('service-worker', () => {
           ['claude', 'chatgpt', 'gemini']
         )
       ).toEqual({
-        enabledProviders: ['chatgpt', 'claude', 'gemini', 'grok', 'deepseek', 'kimi', 'google', 'doubao'],
+        enabledProviders: ['claude', 'chatgpt', 'gemini', 'grok', 'deepseek', 'kimi', 'google', 'doubao'],
         providerOrder: ['claude', 'chatgpt', 'gemini', 'grok', 'deepseek', 'kimi', 'google', 'doubao'],
       });
     });


### PR DESCRIPTION
## Summary
- Preserve reordered legacy provider defaults when migrating users to include Doubao.
- Require a rendered Doubao image preview before treating image injection as successful.
- Prevent auto-submit when Doubao image injection fails and avoid repeated failed uploads.

## Verification
- git diff --check origin/main...HEAD
- npx vitest --run tests/provider-defaults.test.js tests/service-worker.test.js tests/doubao-content-script.test.js