### PR TITLE
Open providers in new tabs with accurate Claude fallback

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -54,7 +54,7 @@
     "message": "Open Claude"
   },
   "openProviderTopLevelTitle": {
-    "message": "Open Claude in a normal tab to use the regular model selector"
+    "message": "Open in new tab"
   },
   "embeddedModelLimitNotice": {
     "message": "Claude may show limited model options when embedded. Open Claude in a normal tab to use the regular model selector."

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -50,6 +50,15 @@
   "switchToPopupModeTitle": {
     "message": "Switch to Popup Mode"
   },
+  "openProviderTopLevel": {
+    "message": "Open Claude"
+  },
+  "openProviderTopLevelTitle": {
+    "message": "Open Claude in a normal tab to use the regular model selector"
+  },
+  "embeddedModelLimitNotice": {
+    "message": "Claude may show limited model options when embedded. Open Claude in a normal tab to use the regular model selector."
+  },
   "msgOpenModeUpdated": {
     "message": "Open mode updated"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -803,7 +803,7 @@
     "message": "打开 Claude"
   },
   "openProviderTopLevelTitle": {
-    "message": "在普通标签页中打开 Claude，以使用常规模型选择器"
+    "message": "在新标签页中打开"
   },
   "embeddedModelLimitNotice": {
     "message": "Claude 在嵌入时可能只显示有限模型。请在普通标签页中打开 Claude，以使用常规模型选择器。"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -799,6 +799,15 @@
   "switchToPopupModeTitle": {
     "message": "切换到弹出窗口模式"
   },
+  "openProviderTopLevel": {
+    "message": "打开 Claude"
+  },
+  "openProviderTopLevelTitle": {
+    "message": "在普通标签页中打开 Claude，以使用常规模型选择器"
+  },
+  "embeddedModelLimitNotice": {
+    "message": "Claude 在嵌入时可能只显示有限模型。请在普通标签页中打开 Claude，以使用常规模型选择器。"
+  },
   "msgOpenModeUpdated": {
     "message": "打开模式已更新"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -803,7 +803,7 @@
     "message": "開啟 Claude"
   },
   "openProviderTopLevelTitle": {
-    "message": "在一般分頁中開啟 Claude，以使用常規模型選擇器"
+    "message": "在新分頁中開啟"
   },
   "embeddedModelLimitNotice": {
     "message": "Claude 在嵌入時可能只顯示有限模型。請在一般分頁中開啟 Claude，以使用常規模型選擇器。"

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -799,6 +799,15 @@
   "switchToPopupModeTitle": {
     "message": "切換到彈出視窗模式"
   },
+  "openProviderTopLevel": {
+    "message": "開啟 Claude"
+  },
+  "openProviderTopLevelTitle": {
+    "message": "在一般分頁中開啟 Claude，以使用常規模型選擇器"
+  },
+  "embeddedModelLimitNotice": {
+    "message": "Claude 在嵌入時可能只顯示有限模型。請在一般分頁中開啟 Claude，以使用常規模型選擇器。"
+  },
   "msgOpenModeUpdated": {
     "message": "開啟模式已更新"
   },

--- a/content-scripts/text-injection-all-providers.js
+++ b/content-scripts/text-injection-all-providers.js
@@ -11,6 +11,7 @@
   const PANELIZE_PROVIDER_IDLE = 'PANELIZE_PROVIDER_IDLE';
   const PANELIZE_PROVIDER_USER_INTERACTION = 'PANELIZE_PROVIDER_USER_INTERACTION';
   const PANELIZE_TEMP_CHAT_ENABLED = 'PANELIZE_TEMP_CHAT_ENABLED';
+  const PANELIZE_PROVIDER_LOCATION = 'PANELIZE_PROVIDER_LOCATION';
   const CHATGPT_STOP_BUTTON_SELECTOR = 'button[data-testid="stop-button"]';
   const CHATGPT_SEND_TRACKING_IDLE_DELAY_MS = 800;
   const CHATGPT_SEND_TRACKING_NO_BUSY_TIMEOUT_MS = 2000;
@@ -426,6 +427,56 @@
       provider,
       context: MULTI_PANEL_PROVIDER_STATUS_CONTEXT
     }, '*');
+  }
+
+  function postProviderLocation(provider = detectProvider()) {
+    if (!provider || window.parent === window) {
+      return;
+    }
+
+    window.parent.postMessage({
+      type: PANELIZE_PROVIDER_LOCATION,
+      provider,
+      url: window.location.href,
+      context: MULTI_PANEL_PROVIDER_STATUS_CONTEXT
+    }, '*');
+  }
+
+  function setupProviderLocationReporting() {
+    let lastReportedUrl = null;
+
+    const reportIfChanged = () => {
+      const currentUrl = window.location.href;
+      if (currentUrl === lastReportedUrl) {
+        return;
+      }
+
+      lastReportedUrl = currentUrl;
+      postProviderLocation();
+    };
+
+    const wrapHistoryMethod = (methodName) => {
+      const original = window.history?.[methodName];
+      if (typeof original !== 'function') {
+        return;
+      }
+
+      try {
+        window.history[methodName] = function(...args) {
+          const result = original.apply(this, args);
+          setTimeout(reportIfChanged, 0);
+          return result;
+        };
+      } catch (error) {
+        console.warn('[Text Injection] Unable to wrap history method:', methodName, error);
+      }
+    };
+
+    wrapHistoryMethod('pushState');
+    wrapHistoryMethod('replaceState');
+    window.addEventListener('popstate', reportIfChanged);
+    window.addEventListener('hashchange', reportIfChanged);
+    reportIfChanged();
   }
 
   function stopMultiPanelUserInteractionTracking() {
@@ -2095,5 +2146,6 @@
   }
 
   // Listen for messages from the multi-panel host
+  setupProviderLocationReporting();
   window.addEventListener('message', handleTextInjection);
 })();

--- a/modules/provider-open-url.js
+++ b/modules/provider-open-url.js
@@ -1,0 +1,87 @@
+import { getGoogleProviderUrl, normalizeGoogleProviderMode } from './google-mode.js';
+
+const PROVIDER_ALLOWED_HOSTS = {
+  chatgpt: new Set(['chatgpt.com', 'chat.openai.com']),
+  claude: new Set(['claude.ai']),
+  gemini: new Set(['gemini.google.com']),
+  grok: new Set(['grok.com']),
+  deepseek: new Set(['chat.deepseek.com']),
+  kimi: new Set(['www.kimi.com', 'kimi.com']),
+  google: new Set(['www.google.com', 'google.com']),
+  doubao: new Set(['www.doubao.com', 'doubao.com'])
+};
+
+function parseHttpUrl(url) {
+  if (!url || typeof url !== 'string') {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function hasAllowedProviderHost(providerId, url) {
+  const allowedHosts = PROVIDER_ALLOWED_HOSTS[providerId];
+  return Boolean(allowedHosts && allowedHosts.has(url.hostname));
+}
+
+export function isProviderAllowedUrl(providerId, rawUrl) {
+  const url = parseHttpUrl(rawUrl);
+  return Boolean(url && hasAllowedProviderHost(providerId, url));
+}
+
+function isGenericPath(url, paths) {
+  return paths.includes(url.pathname);
+}
+
+export function getProviderFallbackUrl(provider, providerMode = null) {
+  if (!provider) {
+    return '';
+  }
+
+  if (provider.id === 'google') {
+    return getGoogleProviderUrl(normalizeGoogleProviderMode(providerMode));
+  }
+
+  return provider.topLevelUrl || provider.url || '';
+}
+
+export function isProviderCurrentUrl(providerId, rawUrl) {
+  const url = parseHttpUrl(rawUrl);
+  if (!url || !hasAllowedProviderHost(providerId, url)) {
+    return false;
+  }
+
+  switch (providerId) {
+    case 'chatgpt':
+      return url.pathname.startsWith('/c/') && url.searchParams.get('temporary-chat') !== 'true';
+    case 'claude':
+      return url.pathname.startsWith('/chat/') && !url.searchParams.has('incognito');
+    case 'gemini':
+      return url.pathname.startsWith('/app/') && url.pathname !== '/app/';
+    case 'grok':
+      return (url.pathname.startsWith('/c/') || url.pathname.startsWith('/chat/')) && url.hash !== '#private';
+    case 'deepseek':
+      return url.pathname.startsWith('/a/chat/s/') || url.pathname.startsWith('/chat/');
+    case 'kimi':
+      return url.pathname.startsWith('/chat/');
+    case 'google':
+      return isGenericPath(url, ['/', '/webhp', '/search']);
+    case 'doubao':
+      return url.pathname.startsWith('/chat/') && url.pathname !== '/chat/';
+    default:
+      return false;
+  }
+}
+
+export function getProviderOpenUrl(provider, reportedUrl = null, providerMode = null) {
+  if (provider && isProviderCurrentUrl(provider.id, reportedUrl)) {
+    return new URL(reportedUrl).toString();
+  }
+
+  return getProviderFallbackUrl(provider, providerMode);
+}

--- a/modules/providers.js
+++ b/modules/providers.js
@@ -5,6 +5,7 @@ export const PROVIDERS = [
     id: 'chatgpt',
     name: 'ChatGPT',
     url: 'https://chatgpt.com',
+    topLevelUrl: 'https://chatgpt.com/',
     icon: '/icons/providers/chatgpt.png',
     iconDark: '/icons/providers/dark/chatgpt.png',
     enabled: true
@@ -24,6 +25,7 @@ export const PROVIDERS = [
     id: 'gemini',
     name: 'Gemini',
     url: 'https://gemini.google.com',
+    topLevelUrl: 'https://gemini.google.com/app',
     icon: '/icons/providers/gemini.png',
     iconDark: '/icons/providers/dark/gemini.png',
     enabled: true
@@ -32,6 +34,7 @@ export const PROVIDERS = [
     id: 'grok',
     name: 'Grok',
     url: 'https://grok.com',
+    topLevelUrl: 'https://grok.com/',
     icon: '/icons/providers/grok.png',
     iconDark: '/icons/providers/dark/grok.png',
     enabled: true
@@ -40,6 +43,7 @@ export const PROVIDERS = [
     id: 'deepseek',
     name: 'DeepSeek',
     url: 'https://chat.deepseek.com',
+    topLevelUrl: 'https://chat.deepseek.com/',
     icon: '/icons/providers/deepseek.png',
     iconDark: '/icons/providers/dark/deepseek.png',
     enabled: true
@@ -48,6 +52,7 @@ export const PROVIDERS = [
     id: 'kimi',
     name: 'Kimi',
     url: 'https://www.kimi.com',
+    topLevelUrl: 'https://www.kimi.com/',
     icon: '/icons/providers/kimi.png',
     iconDark: '/icons/providers/dark/kimi.png',
     enabled: true
@@ -56,6 +61,7 @@ export const PROVIDERS = [
     id: 'google',
     name: 'Google',
     url: 'https://www.google.com/search?udm=50',
+    topLevelUrl: 'https://www.google.com/search?udm=50',
     icon: '/icons/providers/google.png',
     iconDark: '/icons/providers/dark/google.png',
     enabled: true
@@ -64,6 +70,7 @@ export const PROVIDERS = [
     id: 'doubao',
     name: 'Doubao',
     url: 'https://www.doubao.com/chat/',
+    topLevelUrl: 'https://www.doubao.com/chat/',
     icon: '/icons/providers/doubao.png',
     iconDark: '/icons/providers/dark/doubao.png',
     enabled: true

--- a/modules/providers.js
+++ b/modules/providers.js
@@ -13,9 +13,12 @@ export const PROVIDERS = [
     id: 'claude',
     name: 'Claude',
     url: 'https://claude.ai',
+    topLevelUrl: 'https://claude.ai/new',
     icon: '/icons/providers/claude.png',
     iconDark: '/icons/providers/dark/claude.png',
-    enabled: true
+    enabled: true,
+    // Claude can serve a limited model selector when embedded in an extension iframe.
+    embeddedModelSelectionLimited: true
   },
   {
     id: 'gemini',

--- a/multi-panel/multi-panel.css
+++ b/multi-panel/multi-panel.css
@@ -479,12 +479,65 @@ body {
   flex: 1;
   position: relative;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .panel-iframe-container iframe {
+  flex: 1;
+  min-height: 0;
   width: 100%;
-  height: 100%;
+  height: auto;
   border: none;
+}
+
+.embedded-model-limit-notice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: #fff7e6;
+  border-bottom: 1px solid #ffe0a3;
+  color: #8a5a00;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.embedded-model-limit-notice-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.embedded-model-limit-notice .open-provider-top-level-inline-btn {
+  flex: none;
+  padding: 4px 10px;
+  border: 1px solid #e0a93f;
+  border-radius: 4px;
+  background: #ffefcc;
+  color: #8a5a00;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.embedded-model-limit-notice .open-provider-top-level-inline-btn:hover {
+  background: #ffe4ad;
+}
+
+[data-theme="dark"] .embedded-model-limit-notice {
+  background: #3a2f1a;
+  border-bottom-color: #5a4a26;
+  color: #f0c674;
+}
+
+[data-theme="dark"] .embedded-model-limit-notice .open-provider-top-level-inline-btn {
+  border-color: #6b572c;
+  background: #4a3c1f;
+  color: #f0c674;
+}
+
+[data-theme="dark"] .embedded-model-limit-notice .open-provider-top-level-inline-btn:hover {
+  background: #5a4a26;
 }
 
 .panel-loading {

--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -80,6 +80,11 @@ function getDropdownThemePalette() {
   };
 }
 
+function getLocalizedText(key, fallback) {
+  const message = t(key);
+  return message && message !== key ? message : fallback;
+}
+
 function refreshThemeAwareProviderIcons() {
   document.querySelectorAll('img[data-provider-id]').forEach((img) => {
     const provider = getProviderById(img.dataset.providerId);
@@ -212,6 +217,15 @@ function isChatgptProvider(providerId) {
   return providerId === 'chatgpt';
 }
 
+function providerHasEmbeddedModelSelectionLimit(providerId) {
+  const provider = getProviderById(providerId);
+  return Boolean(provider && provider.embeddedModelSelectionLimited);
+}
+
+function getProviderTopLevelUrl(provider) {
+  return provider?.topLevelUrl || provider?.url || '';
+}
+
 function isTemporaryChatSupportedProvider(providerId) {
   return TEMP_CHAT_SUPPORTED_PROVIDERS.has(providerId);
 }
@@ -324,8 +338,15 @@ function getPanelHeaderRightHtml(providerId) {
     ? getGoogleModeSelectHtml()
     : '';
 
+  const openTopLevelBtn = providerHasEmbeddedModelSelectionLimit(providerId)
+    ? `<button class="open-provider-top-level-btn" title="${getLocalizedText('openProviderTopLevelTitle', 'Open Claude in a normal tab to use the regular model selector')}">
+      <span class="material-symbols-outlined">open_in_new</span>
+    </button>`
+    : '';
+
   return `
     ${googleModeSelect}
+    ${openTopLevelBtn}
     <button class="refresh-panel-btn" title="Refresh">
       <span class="material-symbols-outlined">refresh</span>
     </button>
@@ -333,6 +354,31 @@ function getPanelHeaderRightHtml(providerId) {
       <span class="material-symbols-outlined">swap_horiz</span>
     </button>
   `;
+}
+
+function getEmbeddedModelLimitNoticeHtml() {
+  return `<div class="embedded-model-limit-notice">
+        <span class="embedded-model-limit-notice-text">${getLocalizedText('embeddedModelLimitNotice', 'Claude may show limited model options when embedded. Open Claude in a normal tab to use the regular model selector.')}</span>
+        <button class="open-provider-top-level-inline-btn">${getLocalizedText('openProviderTopLevel', 'Open Claude')}</button>
+      </div>`;
+}
+
+// Keep the embedded model limit notice in sync when a panel's provider changes.
+function syncEmbeddedModelLimitNotice(panelEl, providerId) {
+  const container = panelEl.querySelector('.panel-iframe-container');
+  if (!container) {
+    return;
+  }
+
+  const existing = container.querySelector('.embedded-model-limit-notice');
+  if (providerHasEmbeddedModelSelectionLimit(providerId)) {
+    if (!existing) {
+      const iframe = container.querySelector('iframe');
+      iframe.insertAdjacentHTML('beforebegin', getEmbeddedModelLimitNoticeHtml());
+    }
+  } else if (existing) {
+    existing.remove();
+  }
 }
 
 function syncGoogleModeControls() {
@@ -372,11 +418,45 @@ function reloadPanelIframe(panel, overrideUrl = null) {
   panel.iframe = iframe;
 }
 
+async function openProviderTopLevel(providerId) {
+  const provider = getProviderById(providerId);
+  if (!provider) {
+    return;
+  }
+
+  const url = getProviderTopLevelUrl(provider);
+
+  try {
+    if (typeof chrome !== 'undefined' && chrome.tabs?.create) {
+      await chrome.tabs.create({ url });
+      return;
+    }
+
+    window.open(url, '_blank', 'noopener');
+  } catch (error) {
+    console.error('Failed to open provider tab:', error);
+  }
+}
+
 function bindPanelHeaderActions(panelId) {
   const panel = panels.find(p => p.id === panelId);
   const panelEl = document.getElementById(panelId);
   if (!panel || !panelEl) {
     return;
+  }
+
+  const openTopLevelBtn = panelEl.querySelector('.open-provider-top-level-btn');
+  if (openTopLevelBtn) {
+    openTopLevelBtn.addEventListener('click', () => {
+      openProviderTopLevel(panel.providerId);
+    });
+  }
+
+  const openTopLevelInlineBtn = panelEl.querySelector('.open-provider-top-level-inline-btn');
+  if (openTopLevelInlineBtn) {
+    openTopLevelInlineBtn.addEventListener('click', () => {
+      openProviderTopLevel(panel.providerId);
+    });
   }
 
   const refreshBtn = panelEl.querySelector('.refresh-panel-btn');
@@ -1178,6 +1258,10 @@ async function addPanel(providerId) {
 
   const panelGrid = document.getElementById('panel-grid');
 
+  const embeddedModelLimitNotice = providerHasEmbeddedModelSelectionLimit(providerId)
+    ? getEmbeddedModelLimitNoticeHtml()
+    : '';
+
   // Create panel element
   const panelEl = document.createElement('div');
   panelEl.className = 'panel-item';
@@ -1195,6 +1279,7 @@ async function addPanel(providerId) {
         <img src="${getThemeAwareProviderIcon(provider)}" alt="${provider.name}" class="loading-icon" data-provider-id="${provider.id}">
         <span class="loading-text">Loading ${provider.name}...</span>
       </div>
+      ${embeddedModelLimitNotice}
       <iframe
         src="${getProviderFrameUrl(providerId)}"
         sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
@@ -1309,6 +1394,9 @@ async function switchPanelProvider(panelId, newProviderId) {
 
   // Update iframe
   const iframe = panelEl.querySelector('iframe');
+
+  // Add/remove the embedded model limit notice for providers that need it.
+  syncEmbeddedModelLimitNotice(panelEl, newProviderId);
 
   // Update panel data
   panel.providerId = newProviderId;

--- a/multi-panel/multi-panel.js
+++ b/multi-panel/multi-panel.js
@@ -14,6 +14,11 @@ import {
   getGoogleProviderUrl,
   normalizeGoogleProviderMode
 } from '../modules/google-mode.js';
+import {
+  getProviderOpenUrl,
+  isProviderAllowedUrl,
+  isProviderCurrentUrl
+} from '../modules/provider-open-url.js';
 import { saveSetting } from '../modules/settings.js';
 import { applyTheme } from '../modules/theme-manager.js';
 import { t, initializeLanguage } from '../modules/i18n.js';
@@ -113,6 +118,7 @@ const PANELIZE_PROVIDER_BUSY = 'PANELIZE_PROVIDER_BUSY';
 const PANELIZE_PROVIDER_IDLE = 'PANELIZE_PROVIDER_IDLE';
 const PANELIZE_PROVIDER_USER_INTERACTION = 'PANELIZE_PROVIDER_USER_INTERACTION';
 const PANELIZE_TEMP_CHAT_ENABLED = 'PANELIZE_TEMP_CHAT_ENABLED';
+const PANELIZE_PROVIDER_LOCATION = 'PANELIZE_PROVIDER_LOCATION';
 const TEMP_CHAT_RETRY_DELAYS = [1200, 2500, 4000];
 const TEMP_CHAT_OPERATION_TIMEOUT_MS = 5000;
 const TEMP_CHAT_SUPPORTED_PROVIDERS = new Set(['chatgpt', 'gemini', 'claude', 'grok']);
@@ -220,10 +226,6 @@ function isChatgptProvider(providerId) {
 function providerHasEmbeddedModelSelectionLimit(providerId) {
   const provider = getProviderById(providerId);
   return Boolean(provider && provider.embeddedModelSelectionLimited);
-}
-
-function getProviderTopLevelUrl(provider) {
-  return provider?.topLevelUrl || provider?.url || '';
 }
 
 function isTemporaryChatSupportedProvider(providerId) {
@@ -338,11 +340,9 @@ function getPanelHeaderRightHtml(providerId) {
     ? getGoogleModeSelectHtml()
     : '';
 
-  const openTopLevelBtn = providerHasEmbeddedModelSelectionLimit(providerId)
-    ? `<button class="open-provider-top-level-btn" title="${getLocalizedText('openProviderTopLevelTitle', 'Open Claude in a normal tab to use the regular model selector')}">
+  const openTopLevelBtn = `<button class="open-provider-top-level-btn" title="${getLocalizedText('openProviderTopLevelTitle', 'Open in new tab')}">
       <span class="material-symbols-outlined">open_in_new</span>
-    </button>`
-    : '';
+    </button>`;
 
   return `
     ${googleModeSelect}
@@ -414,17 +414,18 @@ function reloadPanelIframe(panel, overrideUrl = null) {
 
   showPanelLoadingState(panelEl, provider);
   loadingPanelIds.add(panel.id);
+  panel.currentUrl = null;
   iframe.src = overrideUrl || getProviderFrameUrl(panel.providerId);
   panel.iframe = iframe;
 }
 
-async function openProviderTopLevel(providerId) {
-  const provider = getProviderById(providerId);
+async function openProviderTopLevel(panel) {
+  const provider = getProviderById(panel?.providerId);
   if (!provider) {
     return;
   }
 
-  const url = getProviderTopLevelUrl(provider);
+  const url = getProviderOpenUrl(provider, panel.currentUrl, getPanelProviderMode(panel));
 
   try {
     if (typeof chrome !== 'undefined' && chrome.tabs?.create) {
@@ -448,14 +449,14 @@ function bindPanelHeaderActions(panelId) {
   const openTopLevelBtn = panelEl.querySelector('.open-provider-top-level-btn');
   if (openTopLevelBtn) {
     openTopLevelBtn.addEventListener('click', () => {
-      openProviderTopLevel(panel.providerId);
+      openProviderTopLevel(panel);
     });
   }
 
   const openTopLevelInlineBtn = panelEl.querySelector('.open-provider-top-level-inline-btn');
   if (openTopLevelInlineBtn) {
     openTopLevelInlineBtn.addEventListener('click', () => {
-      openProviderTopLevel(panel.providerId);
+      openProviderTopLevel(panel);
     });
   }
 
@@ -822,7 +823,8 @@ function handleProviderStatusMessage(event) {
   }
 
   const isTempChatMessage = data.type === PANELIZE_TEMP_CHAT_ENABLED;
-  if (data.context !== MULTI_PANEL_PROVIDER_STATUS_CONTEXT || (!data.requestId && !isTempChatMessage)) {
+  const isLocationMessage = data.type === PANELIZE_PROVIDER_LOCATION;
+  if (data.context !== MULTI_PANEL_PROVIDER_STATUS_CONTEXT || (!data.requestId && !isTempChatMessage && !isLocationMessage)) {
     return;
   }
 
@@ -832,6 +834,12 @@ function handleProviderStatusMessage(event) {
   }
 
   switch (data.type) {
+    case PANELIZE_PROVIDER_LOCATION:
+      if (!isProviderAllowedUrl(panel.providerId, data.url)) {
+        return;
+      }
+      panel.currentUrl = isProviderCurrentUrl(panel.providerId, data.url) ? data.url : null;
+      break;
     case PANELIZE_PROVIDER_BUSY:
       if (!isChatgptProvider(panel.providerId)) {
         return;
@@ -1319,6 +1327,7 @@ async function addPanel(providerId) {
     id: panelId,
     providerId,
     iframe,
+    currentUrl: null,
     state: 'loading'
   });
 
@@ -1401,6 +1410,7 @@ async function switchPanelProvider(panelId, newProviderId) {
   // Update panel data
   panel.providerId = newProviderId;
   panel.iframe = iframe;
+  panel.currentUrl = null;
   bindPanelHeaderActions(panelId);
   reloadPanelIframe(panel);
 

--- a/tests/chatgpt-content-script.test.js
+++ b/tests/chatgpt-content-script.test.js
@@ -15,6 +15,18 @@ function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+async function waitForProviderStatusCall(postMessageSpy, type, expectedLength = 1, timeoutMs = 1200) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const calls = getProviderStatusCalls(postMessageSpy, type);
+    if (calls.length === expectedLength) {
+      return calls;
+    }
+    await wait(25);
+  }
+  return getProviderStatusCalls(postMessageSpy, type);
+}
+
 function createChatgptComposerDom({ includeSendButton = true, includeStopButton = false } = {}) {
   document.body.innerHTML = `
     <form data-type="unified-composer">
@@ -109,7 +121,7 @@ describe('chatgpt content script provider status', () => {
     getStopButton()?.remove();
     await wait(850);
 
-    const idleCalls = getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_IDLE');
+    const idleCalls = await waitForProviderStatusCall(postMessageSpy, 'PANELIZE_PROVIDER_IDLE');
     expect(idleCalls).toHaveLength(1);
     expect(idleCalls[0]).toMatchObject({
       requestId: 'req-idle',
@@ -130,7 +142,7 @@ describe('chatgpt content script provider status', () => {
 
     await wait(100);
     composer.insertAdjacentHTML('beforeend', '<button type="button" data-testid="stop-button" aria-label="Stop streaming">Stop</button>');
-    await wait(50);
+    expect(await waitForProviderStatusCall(postMessageSpy, 'PANELIZE_PROVIDER_BUSY')).toHaveLength(1);
     getStopButton()?.remove();
     await wait(300);
     composer.insertAdjacentHTML('beforeend', '<button type="button" data-testid="stop-button" aria-label="Stop streaming">Stop</button>');
@@ -141,7 +153,7 @@ describe('chatgpt content script provider status', () => {
     getStopButton()?.remove();
     await wait(850);
 
-    expect(getProviderStatusCalls(postMessageSpy, 'PANELIZE_PROVIDER_IDLE')).toHaveLength(1);
+    expect(await waitForProviderStatusCall(postMessageSpy, 'PANELIZE_PROVIDER_IDLE')).toHaveLength(1);
   });
 
   it('stops tracking when busy is never observed within 2 seconds', async () => {

--- a/tests/provider-location-reporting.test.js
+++ b/tests/provider-location-reporting.test.js
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Window } from 'happy-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const contentScriptSource = readFileSync(
+  resolve(process.cwd(), 'content-scripts/text-injection-all-providers.js'),
+  'utf8'
+);
+
+function getLocationReports(postMessageSpy) {
+  return postMessageSpy.mock.calls
+    .map(call => call[0])
+    .filter(payload => payload?.type === 'PANELIZE_PROVIDER_LOCATION' && payload?.context === 'multi-panel-provider-status');
+}
+
+describe('provider location reporting content script', () => {
+  let testWindow;
+
+  beforeEach(() => {
+    testWindow = new Window({ url: 'https://chatgpt.com/c/initial' });
+    Object.defineProperty(testWindow, 'parent', {
+      configurable: true,
+      value: { postMessage: vi.fn() },
+    });
+    testWindow.eval(contentScriptSource);
+  });
+
+  it('reports location on load', () => {
+    const reports = getLocationReports(testWindow.parent.postMessage);
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      provider: 'chatgpt',
+      url: 'https://chatgpt.com/c/initial',
+    });
+  });
+
+  it('reports location after pushState', async () => {
+    testWindow.history.pushState({}, '', '/c/pushed');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(getLocationReports(testWindow.parent.postMessage)).toContainEqual(expect.objectContaining({
+      provider: 'chatgpt',
+      url: 'https://chatgpt.com/c/pushed',
+    }));
+  });
+
+  it('reports location after replaceState', async () => {
+    testWindow.history.replaceState({}, '', '/c/replaced');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(getLocationReports(testWindow.parent.postMessage)).toContainEqual(expect.objectContaining({
+      provider: 'chatgpt',
+      url: 'https://chatgpt.com/c/replaced',
+    }));
+  });
+
+  it('reports location after hashchange', async () => {
+    testWindow.location.hash = 'thread';
+    testWindow.dispatchEvent(new testWindow.HashChangeEvent('hashchange'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(getLocationReports(testWindow.parent.postMessage)).toContainEqual(expect.objectContaining({
+      provider: 'chatgpt',
+      url: 'https://chatgpt.com/c/initial#thread',
+    }));
+  });
+
+  it('reports location after popstate', async () => {
+    testWindow.happyDOM.setURL('https://chatgpt.com/c/popstate-target');
+    testWindow.parent.postMessage.mockClear();
+
+    testWindow.dispatchEvent(new testWindow.PopStateEvent('popstate'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(getLocationReports(testWindow.parent.postMessage)).toContainEqual(expect.objectContaining({
+      provider: 'chatgpt',
+      url: 'https://chatgpt.com/c/popstate-target',
+    }));
+  });
+});

--- a/tests/provider-open-url.test.js
+++ b/tests/provider-open-url.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { getProviderById } from '../modules/providers.js';
+import {
+  getProviderFallbackUrl,
+  getProviderOpenUrl,
+  isProviderAllowedUrl,
+  isProviderCurrentUrl,
+} from '../modules/provider-open-url.js';
+
+describe('provider open URL helpers', () => {
+  it('accepts known current conversation URLs', () => {
+    expect(isProviderCurrentUrl('chatgpt', 'https://chatgpt.com/c/abc123')).toBe(true);
+    expect(isProviderCurrentUrl('claude', 'https://claude.ai/chat/abc123')).toBe(true);
+    expect(isProviderCurrentUrl('gemini', 'https://gemini.google.com/app/abc123')).toBe(true);
+    expect(isProviderCurrentUrl('grok', 'https://grok.com/c/abc123')).toBe(true);
+    expect(isProviderCurrentUrl('deepseek', 'https://chat.deepseek.com/a/chat/s/abc123')).toBe(true);
+    expect(isProviderCurrentUrl('kimi', 'https://www.kimi.com/chat/abc123')).toBe(true);
+    expect(isProviderCurrentUrl('doubao', 'https://www.doubao.com/chat/abc123')).toBe(true);
+  });
+
+  it('accepts current Google pages for both AI Mode and Search', () => {
+    expect(isProviderCurrentUrl('google', 'https://www.google.com/search?udm=50')).toBe(true);
+    expect(isProviderCurrentUrl('google', 'https://www.google.com/search?q=panelize')).toBe(true);
+    expect(isProviderCurrentUrl('google', 'https://www.google.com/')).toBe(true);
+  });
+
+  it('rejects invalid origins, generic pages, and temporary private pages', () => {
+    expect(isProviderAllowedUrl('chatgpt', 'https://evil.example/c/abc123')).toBe(false);
+    expect(isProviderCurrentUrl('chatgpt', 'https://chatgpt.com/')).toBe(false);
+    expect(isProviderCurrentUrl('chatgpt', 'https://chatgpt.com/?temporary-chat=true')).toBe(false);
+    expect(isProviderCurrentUrl('claude', 'https://claude.ai/new?incognito')).toBe(false);
+    expect(isProviderCurrentUrl('gemini', 'https://gemini.google.com/app')).toBe(false);
+    expect(isProviderCurrentUrl('grok', 'https://grok.com/c#private')).toBe(false);
+    expect(isProviderCurrentUrl('kimi', 'https://www.kimi.com/')).toBe(false);
+    expect(isProviderCurrentUrl('doubao', 'https://www.doubao.com/chat/')).toBe(false);
+  });
+
+  it('opens the reported current URL when it is valid', () => {
+    const provider = getProviderById('claude');
+
+    expect(getProviderOpenUrl(provider, 'https://claude.ai/chat/abc123')).toBe('https://claude.ai/chat/abc123');
+  });
+
+  it('falls back when the reported URL is missing or not a current conversation', () => {
+    expect(getProviderOpenUrl(getProviderById('chatgpt'), 'https://chatgpt.com/')).toBe('https://chatgpt.com/');
+    expect(getProviderOpenUrl(getProviderById('claude'), 'https://claude.ai/new?incognito')).toBe('https://claude.ai/new');
+    expect(getProviderOpenUrl(getProviderById('google'), null, 'search')).toBe('https://www.google.com/');
+    expect(getProviderFallbackUrl(getProviderById('google'), 'ai')).toBe('https://www.google.com/search?udm=50');
+  });
+});

--- a/tests/providers.test.js
+++ b/tests/providers.test.js
@@ -33,6 +33,7 @@ describe('providers module', () => {
         expect(provider).toHaveProperty('id');
         expect(provider).toHaveProperty('name');
         expect(provider).toHaveProperty('url');
+        expect(provider).toHaveProperty('topLevelUrl');
         expect(provider).toHaveProperty('icon');
         expect(provider).toHaveProperty('iconDark');
         expect(provider).toHaveProperty('enabled');


### PR DESCRIPTION
## Summary
- Clarify the Claude embedded model limitation instead of implying Panelize can restore the iframe model selector.
- Add an open-in-new-tab button to every provider panel header.
- Add provider URL reporting and validation so panels can open a reported current conversation URL when it is provider-owned and recoverable, otherwise falling back to the provider default page.

## Details
- Adds provider `topLevelUrl` metadata and a shared URL resolver for provider-owned current conversation/current page URLs.
- Adds content-script location reporting on load, history navigation, `popstate`, and `hashchange`.
- Keeps the Claude embedded limitation banner and routes both the inline Claude button and header button through the same open URL resolver.
- Renames the Claude fallback copy away from first-party wording and keeps it accurate for embedded model limits.

## Validation
- `npx vitest run tests/*.test.js`
- `npx playwright test tests/e2e/focus-protection.e2e.test.js --reporter=line`
- Loaded the local extension in a temporary Chromium profile and verified all 8 provider headers show `open_in_new`, the Claude warning remains visible, ChatGPT fallback opens `https://chatgpt.com/`, and Claude inline fallback opens `https://claude.ai/new`.

## Notes
- Current-conversation opening only works when the provider iframe exposes and reports a recoverable conversation URL. Providers that keep the iframe URL at a home/generic route will intentionally fall back to their default page.
