### PR TITLE
Release Panelize 1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.6 - 2026-07-17
+- Fixed update checks for GitHub-installed extensions using GitHub Releases.
+- Added a guarded release workflow that publishes only after the release branch is merged into main.
+
 ## 1.1.1 - 2026-04-13
 - Fixed: New Chat for All now preserves temporary chat mode for supported providers.
 - Fixed: Gemini and Grok temporary or private chat activation no longer toggles off when already active.

--- a/data/version-info.json
+++ b/data/version-info.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
-  "commitHash": "1f42db6",
-  "buildDate": "2026-04-13"
+  "version": "1.2.6",
+  "commitHash": "0409159",
+  "buildDate": "2026-07-17"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Panelize",
-  "version": "1.1.1",
+  "version": "1.2.6",
   "description": "Compare AI assistants side by side in one window. Send one prompt and review responses faster.",
   "default_locale": "en",
   "permissions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panelize",
-  "version": "1.1.1",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panelize",
-      "version": "1.1.1",
+      "version": "1.2.6",
       "devDependencies": {
         "@playwright/test": "^1.58.1",
         "@vitest/ui": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panelize",
-  "version": "1.1.1",
+  "version": "1.2.6",
   "description": "Compare AI chatbots side-by-side",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- bump Panelize metadata from 1.1.1 to 1.2.6
- add the 1.2.6 changelog entry
- prepare the release branch for the guarded publish workflow

## Release changes

- fix update checks for GitHub-installed extensions by using GitHub Releases
- require the release branch to be merged into `main` before publishing

## Validation

- Release Prep workflow completed successfully
- 316 unit tests passed in GitHub Actions
- release and Chrome Web Store ZIP artifacts were generated
- both ZIP files contain `manifest.json` version `1.2.6`

After this PR is merged, run the manual Release Publish workflow with version `1.2.6` and this PR number.
