### PR TITLE
Release 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.7 - 2026-07-17
+- Removed the experimental Claude model override now that Claude provides native model selection when embedded.
+- Added upgrade cleanup and regression coverage for the retired Claude model preference.
+
 ## 1.2.6 - 2026-07-17
 - Fixed update checks for GitHub-installed extensions using GitHub Releases.
 - Added a guarded release workflow that publishes only after the release branch is merged into main.

--- a/data/version-info.json
+++ b/data/version-info.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.6",
-  "commitHash": "0409159",
+  "version": "1.2.7",
+  "commitHash": "08d842a",
   "buildDate": "2026-07-17"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Panelize",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Compare AI assistants side by side in one window. Send one prompt and review responses faster.",
   "default_locale": "en",
   "permissions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panelize",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panelize",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "devDependencies": {
         "@playwright/test": "^1.58.1",
         "@vitest/ui": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panelize",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Compare AI chatbots side-by-side",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- bump Panelize from 1.2.6 to 1.2.7
- document removal of the retired Claude model override workaround
- record upgrade cleanup and regression coverage for the native Claude model-selection path

## Verification

- Release Prep workflow passed: https://github.com/Manho/Panelize/actions/runs/29566971588
- release metadata is limited to the five required files
- both generated ZIP artifacts contain `manifest.json` version `1.2.7`
- generated packages do not contain the retired Claude request-interceptor files

After this PR is merged, run the Release Publish workflow with version `1.2.7` and this PR number.