### PR TITLE
Release Panelize 1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.8 - 2026-07-19
+- Fix Gemini Send All in localized interfaces without affecting image uploads.
+
 ## 1.2.7 - 2026-07-17
 - Removed the experimental Claude model override now that Claude provides native model selection when embedded.
 - Added upgrade cleanup and regression coverage for the retired Claude model preference.

--- a/data/version-info.json
+++ b/data/version-info.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.7",
-  "commitHash": "08d842a",
-  "buildDate": "2026-07-17"
+  "version": "1.2.8",
+  "commitHash": "bd24968",
+  "buildDate": "2026-07-19"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Panelize",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Compare AI assistants side by side in one window. Send one prompt and review responses faster.",
   "default_locale": "en",
   "permissions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panelize",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panelize",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "devDependencies": {
         "@playwright/test": "^1.58.1",
         "@vitest/ui": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panelize",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Compare AI chatbots side-by-side",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Bump Panelize from 1.2.7 to 1.2.8.
- Add the 1.2.8 changelog entry for the localized Gemini Send All fix.
- Refresh release metadata for the Chrome Web Store and GitHub Release packages.

## Included fix

- #63 fixes Gemini Send All in localized interfaces without changing the image-upload path.
- Related issue: #53.

## Validation

- Release Prep: https://github.com/Manho/Panelize/actions/runs/29673444195
- Release PR gate passed locally.
- Unit tests: 36 files and 304 tests passed.
- Both generated ZIPs contain manifest version 1.2.8 and SHA-256 `4afe01e2310c129b08d7478c5f9b0902590ca6f61f6c900e3294007f88af633c`.
